### PR TITLE
add coverage

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,9 +24,21 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
+          components: llvm-tools-preview
         
-      - name: Install nextest
+      - uses: Swatinem/rust-cache@v2
+      
+      - name: Install latest nextest release
         uses: taiki-e/install-action@nextest
+        
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Run cargo test
-        run: cargo nextest run --release --workspace --exclude faer-bench
+      - name: Collect coverage data
+        run: cargo llvm-cov nextest --lcov --output-path lcov.info --release --workspace --exclude faer-bench
+        
+      - name: Upload coverage data to codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: lcov.info
+      


### PR DESCRIPTION
This PR adds coverage reports to the repo. A few notes:

1. It is slower than running `cargo test` due to remediation effort of an issue mentioned here - https://github.com/rust-lang/rust/issues/91092
2. To enable you need to setup team bot -> https://docs.codecov.com/docs/team-bot
3. Additionally, provide codecov access to GitHub -> https://docs.codecov.com/docs/github-oauth-application-authorization#troubleshooting

Theoretically I can update the action to use as many threads as there are logical CPU's for a speed boost. We'd just have less accurate coverage measures. Lemme know your thoughts.