### PR TITLE
Add features to bench crate

### DIFF
--- a/faer-bench/Cargo.toml
+++ b/faer-bench/Cargo.toml
@@ -15,7 +15,6 @@ faer-lu = { path = "../faer-lu", features = ["nightly"] }
 faer-qr = { path = "../faer-qr", features = ["nightly"] }
 faer-svd = { path = "../faer-svd", features = ["nightly"] }
 faer-cholesky = { path = "../faer-cholesky", features = ["nightly"] }
-plotters = "0.3.4"
 human-repr = "1.0.1"
 ndarray-linalg = { version = "0.16.0", features = ["openblas-system"] }
 rand = "0.8.5"

--- a/faer-bench/Cargo.toml
+++ b/faer-bench/Cargo.toml
@@ -29,9 +29,7 @@ num-complex = "0.4.3"
 cc = "1.0.79"
 
 [features]
-default = ["faer", "eigen", "ndarray", "nalgebra"]
+default = ["eigen", "nalgebra"]
 
-faer = []
 eigen = []
-ndarray = []
 nalgebra = []

--- a/faer-bench/Cargo.toml
+++ b/faer-bench/Cargo.toml
@@ -27,3 +27,11 @@ num-complex = "0.4.3"
 
 [build-dependencies]
 cc = "1.0.79"
+
+[features]
+default = ["faer", "eigen", "ndarray", "nalgebra"]
+
+faer = []
+eigen = []
+ndarray = []
+nalgebra = []

--- a/faer-bench/Cargo.toml
+++ b/faer-bench/Cargo.toml
@@ -24,7 +24,7 @@ reborrow = "0.5"
 openmp-sys = "1.2.3"
 num-traits = "0.2.15"
 coe-rs = "0.1.2"
-num-complex.workspace = true
+num-complex = "0.4.3" 
 
 [build-dependencies]
 cc = "1.0.79"

--- a/faer-bench/build.rs
+++ b/faer-bench/build.rs
@@ -2,6 +2,7 @@ fn main() {
     // Tell Cargo that if the given file changes, to rerun this build script.
     println!("cargo:rerun-if-changed=eigen.cpp");
     // Use the `cc` crate to build a C file and statically link it.
+    #[cfg(feature = "eigen")]
     cc::Build::new()
         .cpp(true)
         .flag("-march=native")

--- a/faer-bench/src/main.rs
+++ b/faer-bench/src/main.rs
@@ -107,6 +107,19 @@ macro_rules! printwriteln {
     };
 }
 
+#[cfg(feature = "eigen")]
+macro_rules! ifeigen {
+    ($arg: expr) => {{
+        &$arg
+    }};
+}
+#[cfg(not(feature = "eigen"))]
+macro_rules! ifeigen {
+    ($arg: expr) => {{
+        &vec![Duration::ZERO; N]
+    }};
+}
+
 fn print_results(
     output: &mut dyn Write,
     input_sizes: &[usize],
@@ -149,6 +162,7 @@ fn print_results(
     Ok(())
 }
 
+#[cfg(feature = "eigen")]
 mod eigen {
     extern "C" {
         pub fn gemm_f32(out: *mut f64, inputs: *const usize, count: usize);
@@ -216,8 +230,10 @@ fn eigen(
     v.into_iter().map(Duration::from_secs_f64).collect()
 }
 
+const N: usize = 12;
 fn main() -> Result<()> {
     let input_sizes = vec![32, 64, 96, 128, 192, 256, 384, 512, 640, 768, 896, 1024];
+    assert!(N == input_sizes.len());
 
     {
         println!("f32");
@@ -238,7 +254,7 @@ fn main() -> Result<()> {
             &gemm::faer::<f32>(&input_sizes, Parallelism::Rayon(0)),
             &gemm::ndarray::<f32>(&input_sizes),
             &gemm::nalgebra::<f32>(&input_sizes),
-            &eigen(eigen::gemm_f32, &input_sizes),
+            ifeigen!(&eigen(eigen::gemm_f32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -259,7 +275,7 @@ fn main() -> Result<()> {
             &trsm::faer::<f32>(&input_sizes, Parallelism::Rayon(0)),
             &trsm::ndarray::<f32>(&input_sizes),
             &trsm::nalgebra::<f32>(&input_sizes),
-            &eigen(eigen::trsm_f32, &input_sizes),
+            ifeigen!(&eigen(eigen::trsm_f32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -279,7 +295,7 @@ fn main() -> Result<()> {
             &tr_inverse::faer::<f32>(&input_sizes, Parallelism::Rayon(0)),
             &tr_inverse::ndarray::<f32>(&input_sizes),
             &tr_inverse::nalgebra::<f32>(&input_sizes),
-            &eigen(eigen::trinv_f32, &input_sizes),
+            ifeigen!(&eigen(eigen::trinv_f32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -299,7 +315,7 @@ fn main() -> Result<()> {
             &cholesky::faer::<f32>(&input_sizes, Parallelism::Rayon(0)),
             &cholesky::ndarray::<f32>(&input_sizes),
             &cholesky::nalgebra::<f32>(&input_sizes),
-            &eigen(eigen::chol_f32, &input_sizes),
+            ifeigen!(&eigen(eigen::chol_f32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -320,7 +336,7 @@ fn main() -> Result<()> {
             &partial_piv_lu::faer::<f32>(&input_sizes, Parallelism::Rayon(0)),
             &partial_piv_lu::ndarray::<f32>(&input_sizes),
             &partial_piv_lu::nalgebra::<f32>(&input_sizes),
-            &eigen(eigen::plu_f32, &input_sizes),
+            ifeigen!(&eigen(eigen::plu_f32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -341,7 +357,7 @@ fn main() -> Result<()> {
             &full_piv_lu::faer::<f32>(&input_sizes, Parallelism::Rayon(0)),
             &full_piv_lu::ndarray::<f32>(&input_sizes),
             &full_piv_lu::nalgebra::<f32>(&input_sizes),
-            &eigen(eigen::flu_f32, &input_sizes),
+            ifeigen!(&eigen(eigen::flu_f32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -362,7 +378,7 @@ fn main() -> Result<()> {
             &no_piv_qr::faer::<f32>(&input_sizes, Parallelism::Rayon(0)),
             &no_piv_qr::ndarray::<f32>(&input_sizes),
             &no_piv_qr::nalgebra::<f32>(&input_sizes),
-            &eigen(eigen::qr_f32, &input_sizes),
+            ifeigen!(&eigen(eigen::qr_f32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -383,7 +399,7 @@ fn main() -> Result<()> {
             &col_piv_qr::faer::<f32>(&input_sizes, Parallelism::Rayon(0)),
             &col_piv_qr::ndarray::<f32>(&input_sizes),
             &col_piv_qr::nalgebra::<f32>(&input_sizes),
-            &eigen(eigen::colqr_f32, &input_sizes),
+            ifeigen!(&eigen(eigen::colqr_f32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -403,7 +419,7 @@ fn main() -> Result<()> {
             &inverse::faer::<f32>(&input_sizes, Parallelism::Rayon(0)),
             &inverse::ndarray::<f32>(&input_sizes),
             &inverse::nalgebra::<f32>(&input_sizes),
-            &eigen(eigen::inverse_f32, &input_sizes),
+            ifeigen!(&eigen(eigen::inverse_f32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -423,7 +439,7 @@ Computing the SVD of a square matrix with dimension `n`.
             &svd::faer::<f32>(&input_sizes, Parallelism::Rayon(0)),
             &svd::ndarray::<f32>(&input_sizes),
             &svd::nalgebra::<f32>(&input_sizes),
-            &eigen(eigen::svd_f32, &input_sizes),
+            ifeigen!(&eigen(eigen::svd_f32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -443,7 +459,7 @@ Computing the SVD of a rectangular matrix with shape `(4096, n)`.
             &rectangular_svd::faer::<f32>(&input_sizes, Parallelism::Rayon(0)),
             &rectangular_svd::ndarray::<f32>(&input_sizes),
             &rectangular_svd::nalgebra::<f32>(&input_sizes),
-            &eigen(eigen::rectangular_svd_f32, &input_sizes),
+            ifeigen!(&eigen(eigen::rectangular_svd_f32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
     }
@@ -466,7 +482,7 @@ Multiplication of two square matrices of dimension `n`.
             &gemm::faer::<f64>(&input_sizes, Parallelism::Rayon(0)),
             &gemm::ndarray::<f64>(&input_sizes),
             &gemm::nalgebra::<f64>(&input_sizes),
-            &eigen(eigen::gemm_f64, &input_sizes),
+            ifeigen!(&eigen(eigen::gemm_f64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -483,7 +499,7 @@ Solving `AX = B` in place where `A` and `B` are two square matrices of dimension
             &trsm::faer::<f64>(&input_sizes, Parallelism::Rayon(0)),
             &trsm::ndarray::<f64>(&input_sizes),
             &trsm::nalgebra::<f64>(&input_sizes),
-            &eigen(eigen::trsm_f64, &input_sizes),
+            ifeigen!(&eigen(eigen::trsm_f64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -503,7 +519,7 @@ Computing `A^-1` where `A` is a square triangular matrix with dimension `n`.
             &tr_inverse::faer::<f64>(&input_sizes, Parallelism::Rayon(0)),
             &tr_inverse::ndarray::<f64>(&input_sizes),
             &tr_inverse::nalgebra::<f64>(&input_sizes),
-            &eigen(eigen::trinv_f64, &input_sizes),
+            ifeigen!(&eigen(eigen::trinv_f64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -523,7 +539,7 @@ Factorizing a square matrix with dimension `n` as `L×L.T`, where `L` is lower t
             &cholesky::faer::<f64>(&input_sizes, Parallelism::Rayon(0)),
             &cholesky::ndarray::<f64>(&input_sizes),
             &cholesky::nalgebra::<f64>(&input_sizes),
-            &eigen(eigen::chol_f64, &input_sizes),
+            ifeigen!(&eigen(eigen::chol_f64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -540,7 +556,7 @@ Factorizing a square matrix with dimension `n` as `P×L×U`, where `P` is a perm
             &partial_piv_lu::faer::<f64>(&input_sizes, Parallelism::Rayon(0)),
             &partial_piv_lu::ndarray::<f64>(&input_sizes),
             &partial_piv_lu::nalgebra::<f64>(&input_sizes),
-            &eigen(eigen::plu_f64, &input_sizes),
+            ifeigen!(&eigen(eigen::plu_f64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -557,7 +573,7 @@ Factorizing a square matrix with dimension `n` as `P×L×U×Q.T`, where `P` and 
             &full_piv_lu::faer::<f64>(&input_sizes, Parallelism::Rayon(0)),
             &full_piv_lu::ndarray::<f64>(&input_sizes),
             &full_piv_lu::nalgebra::<f64>(&input_sizes),
-            &eigen(eigen::flu_f64, &input_sizes),
+            ifeigen!(&eigen(eigen::flu_f64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -574,7 +590,7 @@ Factorizing a square matrix with dimension `n` as `QR`, where `Q` is unitary and
             &no_piv_qr::faer::<f64>(&input_sizes, Parallelism::Rayon(0)),
             &no_piv_qr::ndarray::<f64>(&input_sizes),
             &no_piv_qr::nalgebra::<f64>(&input_sizes),
-            &eigen(eigen::qr_f64, &input_sizes),
+            ifeigen!(&eigen(eigen::qr_f64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -591,7 +607,7 @@ Factorizing a square matrix with dimension `n` as `QRP`, where `P` is a permutat
             &col_piv_qr::faer::<f64>(&input_sizes, Parallelism::Rayon(0)),
             &col_piv_qr::ndarray::<f64>(&input_sizes),
             &col_piv_qr::nalgebra::<f64>(&input_sizes),
-            &eigen(eigen::colqr_f64, &input_sizes),
+            ifeigen!(&eigen(eigen::colqr_f64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -611,7 +627,7 @@ Computing the inverse of a square matrix with dimension `n`.
             &inverse::faer::<f64>(&input_sizes, Parallelism::Rayon(0)),
             &inverse::ndarray::<f64>(&input_sizes),
             &inverse::nalgebra::<f64>(&input_sizes),
-            &eigen(eigen::inverse_f64, &input_sizes),
+            ifeigen!(&eigen(eigen::inverse_f64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -631,7 +647,7 @@ Computing the SVD of a square matrix with dimension `n`.
             &svd::faer::<f64>(&input_sizes, Parallelism::Rayon(0)),
             &svd::ndarray::<f64>(&input_sizes),
             &svd::nalgebra::<f64>(&input_sizes),
-            &eigen(eigen::svd_f64, &input_sizes),
+            ifeigen!(&eigen(eigen::svd_f64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -651,7 +667,7 @@ Computing the SVD of a rectangular matrix with shape `(4096, n)`.
             &rectangular_svd::faer::<f64>(&input_sizes, Parallelism::Rayon(0)),
             &rectangular_svd::ndarray::<f64>(&input_sizes),
             &rectangular_svd::nalgebra::<f64>(&input_sizes),
-            &eigen(eigen::rectangular_svd_f64, &input_sizes),
+            ifeigen!(&eigen(eigen::rectangular_svd_f64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
     }
@@ -674,7 +690,7 @@ Multiplication of two square matrices of dimension `n`.
             &gemm::faer::<c32>(&input_sizes, Parallelism::Rayon(0)),
             &gemm::ndarray::<Cplx32>(&input_sizes),
             &gemm::nalgebra::<Cplx32>(&input_sizes),
-            &eigen(eigen::gemm_c32, &input_sizes),
+            ifeigen!(&eigen(eigen::gemm_c32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -691,7 +707,7 @@ Solving `AX = B` in place where `A` and `B` are two square matrices of dimension
             &trsm::faer::<c32>(&input_sizes, Parallelism::Rayon(0)),
             &trsm::ndarray::<Cplx32>(&input_sizes),
             &trsm::nalgebra::<Cplx32>(&input_sizes),
-            &eigen(eigen::trsm_c32, &input_sizes),
+            ifeigen!(&eigen(eigen::trsm_c32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -711,7 +727,7 @@ Computing `A^-1` where `A` is a square triangular matrix with dimension `n`.
             &tr_inverse::faer::<c32>(&input_sizes, Parallelism::Rayon(0)),
             &tr_inverse::ndarray::<Cplx32>(&input_sizes),
             &tr_inverse::nalgebra::<Cplx32>(&input_sizes),
-            &eigen(eigen::trinv_c32, &input_sizes),
+            ifeigen!(&eigen(eigen::trinv_c32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -731,7 +747,7 @@ Factorizing a square matrix with dimension `n` as `L×L.T`, where `L` is lower t
             &cholesky::faer::<c32>(&input_sizes, Parallelism::Rayon(0)),
             &cholesky::ndarray::<Cplx32>(&input_sizes),
             &cholesky::nalgebra::<Cplx32>(&input_sizes),
-            &eigen(eigen::chol_c32, &input_sizes),
+            ifeigen!(&eigen(eigen::chol_c32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -748,7 +764,7 @@ Factorizing a square matrix with dimension `n` as `P×L×U`, where `P` is a perm
             &partial_piv_lu::faer::<c32>(&input_sizes, Parallelism::Rayon(0)),
             &partial_piv_lu::ndarray::<Cplx32>(&input_sizes),
             &partial_piv_lu::nalgebra::<Cplx32>(&input_sizes),
-            &eigen(eigen::plu_c32, &input_sizes),
+            ifeigen!(&eigen(eigen::plu_c32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -765,7 +781,7 @@ Factorizing a square matrix with dimension `n` as `P×L×U×Q.T`, where `P` and 
             &full_piv_lu::faer::<c32>(&input_sizes, Parallelism::Rayon(0)),
             &full_piv_lu::ndarray::<Cplx32>(&input_sizes),
             &full_piv_lu::nalgebra::<Cplx32>(&input_sizes),
-            &eigen(eigen::flu_c32, &input_sizes),
+            ifeigen!(&eigen(eigen::flu_c32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -782,7 +798,7 @@ Factorizing a square matrix with dimension `n` as `QR`, where `Q` is unitary and
             &no_piv_qr::faer::<c32>(&input_sizes, Parallelism::Rayon(0)),
             &no_piv_qr::ndarray::<Cplx32>(&input_sizes),
             &no_piv_qr::nalgebra::<Cplx32>(&input_sizes),
-            &eigen(eigen::qr_c32, &input_sizes),
+            ifeigen!(&eigen(eigen::qr_c32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -799,7 +815,7 @@ Factorizing a square matrix with dimension `n` as `QRP`, where `P` is a permutat
             &col_piv_qr::faer::<c32>(&input_sizes, Parallelism::Rayon(0)),
             &col_piv_qr::ndarray::<Cplx32>(&input_sizes),
             &col_piv_qr::nalgebra::<Cplx32>(&input_sizes),
-            &eigen(eigen::colqr_c32, &input_sizes),
+            ifeigen!(&eigen(eigen::colqr_c32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -819,7 +835,7 @@ Computing the inverse of a square matrix with dimension `n`.
             &inverse::faer::<c32>(&input_sizes, Parallelism::Rayon(0)),
             &inverse::ndarray::<Cplx32>(&input_sizes),
             &inverse::nalgebra::<Cplx32>(&input_sizes),
-            &eigen(eigen::inverse_c32, &input_sizes),
+            ifeigen!(&eigen(eigen::inverse_c32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -839,7 +855,7 @@ Computing the SVD of a square matrix with dimension `n`.
             &svd::faer::<c32>(&input_sizes, Parallelism::Rayon(0)),
             &svd::ndarray::<Cplx32>(&input_sizes),
             &svd::nalgebra::<Cplx32>(&input_sizes),
-            &eigen(eigen::svd_c32, &input_sizes),
+            ifeigen!(&eigen(eigen::svd_c32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -859,7 +875,7 @@ Computing the SVD of a rectangular matrix with shape `(4096, n)`.
             &rectangular_svd::faer::<c32>(&input_sizes, Parallelism::Rayon(0)),
             &rectangular_svd::ndarray::<Cplx32>(&input_sizes),
             &rectangular_svd::nalgebra::<Cplx32>(&input_sizes),
-            &eigen(eigen::rectangular_svd_c32, &input_sizes),
+            ifeigen!(&eigen(eigen::rectangular_svd_c32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
     }
@@ -882,7 +898,7 @@ Multiplication of two square matrices of dimension `n`.
             &gemm::faer::<c64>(&input_sizes, Parallelism::Rayon(0)),
             &gemm::ndarray::<Cplx64>(&input_sizes),
             &gemm::nalgebra::<Cplx64>(&input_sizes),
-            &eigen(eigen::gemm_c64, &input_sizes),
+            ifeigen!(&eigen(eigen::gemm_c64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -899,7 +915,7 @@ Solving `AX = B` in place where `A` and `B` are two square matrices of dimension
             &trsm::faer::<c64>(&input_sizes, Parallelism::Rayon(0)),
             &trsm::ndarray::<Cplx64>(&input_sizes),
             &trsm::nalgebra::<Cplx64>(&input_sizes),
-            &eigen(eigen::trsm_c64, &input_sizes),
+            ifeigen!(&eigen(eigen::trsm_c64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -919,7 +935,7 @@ Computing `A^-1` where `A` is a square triangular matrix with dimension `n`.
             &tr_inverse::faer::<c64>(&input_sizes, Parallelism::Rayon(0)),
             &tr_inverse::ndarray::<Cplx64>(&input_sizes),
             &tr_inverse::nalgebra::<Cplx64>(&input_sizes),
-            &eigen(eigen::trinv_c64, &input_sizes),
+            ifeigen!(&eigen(eigen::trinv_c64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -939,7 +955,7 @@ Factorizing a square matrix with dimension `n` as `L×L.T`, where `L` is lower t
             &cholesky::faer::<c64>(&input_sizes, Parallelism::Rayon(0)),
             &cholesky::ndarray::<Cplx64>(&input_sizes),
             &cholesky::nalgebra::<Cplx64>(&input_sizes),
-            &eigen(eigen::chol_c64, &input_sizes),
+            ifeigen!(&eigen(eigen::chol_c64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -956,7 +972,7 @@ Factorizing a square matrix with dimension `n` as `P×L×U`, where `P` is a perm
             &partial_piv_lu::faer::<c64>(&input_sizes, Parallelism::Rayon(0)),
             &partial_piv_lu::ndarray::<Cplx64>(&input_sizes),
             &partial_piv_lu::nalgebra::<Cplx64>(&input_sizes),
-            &eigen(eigen::plu_c64, &input_sizes),
+            ifeigen!(&eigen(eigen::plu_c64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -973,7 +989,7 @@ Factorizing a square matrix with dimension `n` as `P×L×U×Q.T`, where `P` and 
             &full_piv_lu::faer::<c64>(&input_sizes, Parallelism::Rayon(0)),
             &full_piv_lu::ndarray::<Cplx64>(&input_sizes),
             &full_piv_lu::nalgebra::<Cplx64>(&input_sizes),
-            &eigen(eigen::flu_c64, &input_sizes),
+            ifeigen!(&eigen(eigen::flu_c64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -990,7 +1006,7 @@ Factorizing a square matrix with dimension `n` as `QR`, where `Q` is unitary and
             &no_piv_qr::faer::<c64>(&input_sizes, Parallelism::Rayon(0)),
             &no_piv_qr::ndarray::<Cplx64>(&input_sizes),
             &no_piv_qr::nalgebra::<Cplx64>(&input_sizes),
-            &eigen(eigen::qr_c64, &input_sizes),
+            ifeigen!(&eigen(eigen::qr_c64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -1007,7 +1023,7 @@ Factorizing a square matrix with dimension `n` as `QRP`, where `P` is a permutat
             &col_piv_qr::faer::<c64>(&input_sizes, Parallelism::Rayon(0)),
             &col_piv_qr::ndarray::<Cplx64>(&input_sizes),
             &col_piv_qr::nalgebra::<Cplx64>(&input_sizes),
-            &eigen(eigen::colqr_c64, &input_sizes),
+            ifeigen!(&eigen(eigen::colqr_c64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -1027,7 +1043,7 @@ Computing the inverse of a square matrix with dimension `n`.
             &inverse::faer::<c64>(&input_sizes, Parallelism::Rayon(0)),
             &inverse::ndarray::<Cplx64>(&input_sizes),
             &inverse::nalgebra::<Cplx64>(&input_sizes),
-            &eigen(eigen::inverse_c64, &input_sizes),
+            ifeigen!(&eigen(eigen::inverse_c64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -1047,7 +1063,7 @@ Computing the SVD of a square matrix with dimension `n`.
             &svd::faer::<c64>(&input_sizes, Parallelism::Rayon(0)),
             &svd::ndarray::<Cplx64>(&input_sizes),
             &svd::nalgebra::<Cplx64>(&input_sizes),
-            &eigen(eigen::svd_c64, &input_sizes),
+            ifeigen!(&eigen(eigen::svd_c64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
 
@@ -1067,7 +1083,7 @@ Computing the SVD of a rectangular matrix with shape `(4096, n)`.
             &rectangular_svd::faer::<c64>(&input_sizes, Parallelism::Rayon(0)),
             &rectangular_svd::ndarray::<Cplx64>(&input_sizes),
             &rectangular_svd::nalgebra::<Cplx64>(&input_sizes),
-            &eigen(eigen::rectangular_svd_c64, &input_sizes),
+            ifeigen!(&eigen(eigen::rectangular_svd_c64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
     }

--- a/faer-bench/src/main.rs
+++ b/faer-bench/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use coe::is_same;
 use eyre::Result;
 use faer_core::{c32, c64, Parallelism};
@@ -105,6 +106,19 @@ macro_rules! printwriteln {
             writeln!($out, $($arg)*)
         }
     };
+}
+
+#[cfg(feature = "nalgebra")]
+macro_rules! ifnalgebra {
+    ($arg: expr) => {{
+        &$arg
+    }};
+}
+#[cfg(not(feature = "nalgebra"))]
+macro_rules! ifnalgebra {
+    ($arg: expr) => {{
+        &vec![Duration::ZERO; N]
+    }};
 }
 
 #[cfg(feature = "eigen")]
@@ -232,8 +246,7 @@ fn eigen(
 
 const N: usize = 12;
 fn main() -> Result<()> {
-    let input_sizes = vec![32, 64, 96, 128, 192, 256, 384, 512, 640, 768, 896, 1024];
-    assert!(N == input_sizes.len());
+    let input_sizes: [usize; N] = [32, 64, 96, 128, 192, 256, 384, 512, 640, 768, 896, 1024];
 
     {
         println!("f32");
@@ -253,7 +266,7 @@ fn main() -> Result<()> {
             &gemm::faer::<f32>(&input_sizes, Parallelism::None),
             &gemm::faer::<f32>(&input_sizes, Parallelism::Rayon(0)),
             &gemm::ndarray::<f32>(&input_sizes),
-            &gemm::nalgebra::<f32>(&input_sizes),
+            ifnalgebra!(&gemm::nalgebra::<f32>(&input_sizes)),
             ifeigen!(&eigen(eigen::gemm_f32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -274,7 +287,7 @@ fn main() -> Result<()> {
             &trsm::faer::<f32>(&input_sizes, Parallelism::None),
             &trsm::faer::<f32>(&input_sizes, Parallelism::Rayon(0)),
             &trsm::ndarray::<f32>(&input_sizes),
-            &trsm::nalgebra::<f32>(&input_sizes),
+            ifnalgebra!(&trsm::nalgebra::<f32>(&input_sizes)),
             ifeigen!(&eigen(eigen::trsm_f32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -294,7 +307,7 @@ fn main() -> Result<()> {
             &tr_inverse::faer::<f32>(&input_sizes, Parallelism::None),
             &tr_inverse::faer::<f32>(&input_sizes, Parallelism::Rayon(0)),
             &tr_inverse::ndarray::<f32>(&input_sizes),
-            &tr_inverse::nalgebra::<f32>(&input_sizes),
+            ifnalgebra!(&tr_inverse::nalgebra::<f32>(&input_sizes)),
             ifeigen!(&eigen(eigen::trinv_f32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -314,7 +327,7 @@ fn main() -> Result<()> {
             &cholesky::faer::<f32>(&input_sizes, Parallelism::None),
             &cholesky::faer::<f32>(&input_sizes, Parallelism::Rayon(0)),
             &cholesky::ndarray::<f32>(&input_sizes),
-            &cholesky::nalgebra::<f32>(&input_sizes),
+            ifnalgebra!(&cholesky::nalgebra::<f32>(&input_sizes)),
             ifeigen!(&eigen(eigen::chol_f32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -335,7 +348,7 @@ fn main() -> Result<()> {
             &partial_piv_lu::faer::<f32>(&input_sizes, Parallelism::None),
             &partial_piv_lu::faer::<f32>(&input_sizes, Parallelism::Rayon(0)),
             &partial_piv_lu::ndarray::<f32>(&input_sizes),
-            &partial_piv_lu::nalgebra::<f32>(&input_sizes),
+            ifnalgebra!(&partial_piv_lu::nalgebra::<f32>(&input_sizes)),
             ifeigen!(&eigen(eigen::plu_f32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -356,7 +369,7 @@ fn main() -> Result<()> {
             &full_piv_lu::faer::<f32>(&input_sizes, Parallelism::None),
             &full_piv_lu::faer::<f32>(&input_sizes, Parallelism::Rayon(0)),
             &full_piv_lu::ndarray::<f32>(&input_sizes),
-            &full_piv_lu::nalgebra::<f32>(&input_sizes),
+            ifnalgebra!(&full_piv_lu::nalgebra::<f32>(&input_sizes)),
             ifeigen!(&eigen(eigen::flu_f32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -377,7 +390,7 @@ fn main() -> Result<()> {
             &no_piv_qr::faer::<f32>(&input_sizes, Parallelism::None),
             &no_piv_qr::faer::<f32>(&input_sizes, Parallelism::Rayon(0)),
             &no_piv_qr::ndarray::<f32>(&input_sizes),
-            &no_piv_qr::nalgebra::<f32>(&input_sizes),
+            ifnalgebra!(&no_piv_qr::nalgebra::<f32>(&input_sizes)),
             ifeigen!(&eigen(eigen::qr_f32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -398,7 +411,7 @@ fn main() -> Result<()> {
             &col_piv_qr::faer::<f32>(&input_sizes, Parallelism::None),
             &col_piv_qr::faer::<f32>(&input_sizes, Parallelism::Rayon(0)),
             &col_piv_qr::ndarray::<f32>(&input_sizes),
-            &col_piv_qr::nalgebra::<f32>(&input_sizes),
+            ifnalgebra!(&col_piv_qr::nalgebra::<f32>(&input_sizes)),
             ifeigen!(&eigen(eigen::colqr_f32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -418,7 +431,7 @@ fn main() -> Result<()> {
             &inverse::faer::<f32>(&input_sizes, Parallelism::None),
             &inverse::faer::<f32>(&input_sizes, Parallelism::Rayon(0)),
             &inverse::ndarray::<f32>(&input_sizes),
-            &inverse::nalgebra::<f32>(&input_sizes),
+            ifnalgebra!(&inverse::nalgebra::<f32>(&input_sizes)),
             ifeigen!(&eigen(eigen::inverse_f32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -438,7 +451,7 @@ Computing the SVD of a square matrix with dimension `n`.
             &svd::faer::<f32>(&input_sizes, Parallelism::None),
             &svd::faer::<f32>(&input_sizes, Parallelism::Rayon(0)),
             &svd::ndarray::<f32>(&input_sizes),
-            &svd::nalgebra::<f32>(&input_sizes),
+            ifnalgebra!(&svd::nalgebra::<f32>(&input_sizes)),
             ifeigen!(&eigen(eigen::svd_f32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -458,7 +471,7 @@ Computing the SVD of a rectangular matrix with shape `(4096, n)`.
             &rectangular_svd::faer::<f32>(&input_sizes, Parallelism::None),
             &rectangular_svd::faer::<f32>(&input_sizes, Parallelism::Rayon(0)),
             &rectangular_svd::ndarray::<f32>(&input_sizes),
-            &rectangular_svd::nalgebra::<f32>(&input_sizes),
+            ifnalgebra!(&rectangular_svd::nalgebra::<f32>(&input_sizes)),
             ifeigen!(&eigen(eigen::rectangular_svd_f32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -481,7 +494,7 @@ Multiplication of two square matrices of dimension `n`.
             &gemm::faer::<f64>(&input_sizes, Parallelism::None),
             &gemm::faer::<f64>(&input_sizes, Parallelism::Rayon(0)),
             &gemm::ndarray::<f64>(&input_sizes),
-            &gemm::nalgebra::<f64>(&input_sizes),
+            ifnalgebra!(&gemm::nalgebra::<f64>(&input_sizes)),
             ifeigen!(&eigen(eigen::gemm_f64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -498,7 +511,7 @@ Solving `AX = B` in place where `A` and `B` are two square matrices of dimension
             &trsm::faer::<f64>(&input_sizes, Parallelism::None),
             &trsm::faer::<f64>(&input_sizes, Parallelism::Rayon(0)),
             &trsm::ndarray::<f64>(&input_sizes),
-            &trsm::nalgebra::<f64>(&input_sizes),
+            ifnalgebra!(&trsm::nalgebra::<f64>(&input_sizes)),
             ifeigen!(&eigen(eigen::trsm_f64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -518,7 +531,7 @@ Computing `A^-1` where `A` is a square triangular matrix with dimension `n`.
             &tr_inverse::faer::<f64>(&input_sizes, Parallelism::None),
             &tr_inverse::faer::<f64>(&input_sizes, Parallelism::Rayon(0)),
             &tr_inverse::ndarray::<f64>(&input_sizes),
-            &tr_inverse::nalgebra::<f64>(&input_sizes),
+            ifnalgebra!(&tr_inverse::nalgebra::<f64>(&input_sizes)),
             ifeigen!(&eigen(eigen::trinv_f64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -538,7 +551,7 @@ Factorizing a square matrix with dimension `n` as `L×L.T`, where `L` is lower t
             &cholesky::faer::<f64>(&input_sizes, Parallelism::None),
             &cholesky::faer::<f64>(&input_sizes, Parallelism::Rayon(0)),
             &cholesky::ndarray::<f64>(&input_sizes),
-            &cholesky::nalgebra::<f64>(&input_sizes),
+            ifnalgebra!(&cholesky::nalgebra::<f64>(&input_sizes)),
             ifeigen!(&eigen(eigen::chol_f64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -555,7 +568,7 @@ Factorizing a square matrix with dimension `n` as `P×L×U`, where `P` is a perm
             &partial_piv_lu::faer::<f64>(&input_sizes, Parallelism::None),
             &partial_piv_lu::faer::<f64>(&input_sizes, Parallelism::Rayon(0)),
             &partial_piv_lu::ndarray::<f64>(&input_sizes),
-            &partial_piv_lu::nalgebra::<f64>(&input_sizes),
+            ifnalgebra!(&partial_piv_lu::nalgebra::<f64>(&input_sizes)),
             ifeigen!(&eigen(eigen::plu_f64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -572,7 +585,7 @@ Factorizing a square matrix with dimension `n` as `P×L×U×Q.T`, where `P` and 
             &full_piv_lu::faer::<f64>(&input_sizes, Parallelism::None),
             &full_piv_lu::faer::<f64>(&input_sizes, Parallelism::Rayon(0)),
             &full_piv_lu::ndarray::<f64>(&input_sizes),
-            &full_piv_lu::nalgebra::<f64>(&input_sizes),
+            ifnalgebra!(&full_piv_lu::nalgebra::<f64>(&input_sizes)),
             ifeigen!(&eigen(eigen::flu_f64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -589,7 +602,7 @@ Factorizing a square matrix with dimension `n` as `QR`, where `Q` is unitary and
             &no_piv_qr::faer::<f64>(&input_sizes, Parallelism::None),
             &no_piv_qr::faer::<f64>(&input_sizes, Parallelism::Rayon(0)),
             &no_piv_qr::ndarray::<f64>(&input_sizes),
-            &no_piv_qr::nalgebra::<f64>(&input_sizes),
+            ifnalgebra!(&no_piv_qr::nalgebra::<f64>(&input_sizes)),
             ifeigen!(&eigen(eigen::qr_f64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -606,7 +619,7 @@ Factorizing a square matrix with dimension `n` as `QRP`, where `P` is a permutat
             &col_piv_qr::faer::<f64>(&input_sizes, Parallelism::None),
             &col_piv_qr::faer::<f64>(&input_sizes, Parallelism::Rayon(0)),
             &col_piv_qr::ndarray::<f64>(&input_sizes),
-            &col_piv_qr::nalgebra::<f64>(&input_sizes),
+            ifnalgebra!(&col_piv_qr::nalgebra::<f64>(&input_sizes)),
             ifeigen!(&eigen(eigen::colqr_f64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -626,7 +639,7 @@ Computing the inverse of a square matrix with dimension `n`.
             &inverse::faer::<f64>(&input_sizes, Parallelism::None),
             &inverse::faer::<f64>(&input_sizes, Parallelism::Rayon(0)),
             &inverse::ndarray::<f64>(&input_sizes),
-            &inverse::nalgebra::<f64>(&input_sizes),
+            ifnalgebra!(&inverse::nalgebra::<f64>(&input_sizes)),
             ifeigen!(&eigen(eigen::inverse_f64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -646,7 +659,7 @@ Computing the SVD of a square matrix with dimension `n`.
             &svd::faer::<f64>(&input_sizes, Parallelism::None),
             &svd::faer::<f64>(&input_sizes, Parallelism::Rayon(0)),
             &svd::ndarray::<f64>(&input_sizes),
-            &svd::nalgebra::<f64>(&input_sizes),
+            ifnalgebra!(&svd::nalgebra::<f64>(&input_sizes)),
             ifeigen!(&eigen(eigen::svd_f64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -666,7 +679,7 @@ Computing the SVD of a rectangular matrix with shape `(4096, n)`.
             &rectangular_svd::faer::<f64>(&input_sizes, Parallelism::None),
             &rectangular_svd::faer::<f64>(&input_sizes, Parallelism::Rayon(0)),
             &rectangular_svd::ndarray::<f64>(&input_sizes),
-            &rectangular_svd::nalgebra::<f64>(&input_sizes),
+            ifnalgebra!(&rectangular_svd::nalgebra::<f64>(&input_sizes)),
             ifeigen!(&eigen(eigen::rectangular_svd_f64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -689,7 +702,7 @@ Multiplication of two square matrices of dimension `n`.
             &gemm::faer::<c32>(&input_sizes, Parallelism::None),
             &gemm::faer::<c32>(&input_sizes, Parallelism::Rayon(0)),
             &gemm::ndarray::<Cplx32>(&input_sizes),
-            &gemm::nalgebra::<Cplx32>(&input_sizes),
+            ifnalgebra!(&gemm::nalgebra::<Cplx32>(&input_sizes)),
             ifeigen!(&eigen(eigen::gemm_c32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -706,7 +719,7 @@ Solving `AX = B` in place where `A` and `B` are two square matrices of dimension
             &trsm::faer::<c32>(&input_sizes, Parallelism::None),
             &trsm::faer::<c32>(&input_sizes, Parallelism::Rayon(0)),
             &trsm::ndarray::<Cplx32>(&input_sizes),
-            &trsm::nalgebra::<Cplx32>(&input_sizes),
+            ifnalgebra!(&trsm::nalgebra::<Cplx32>(&input_sizes)),
             ifeigen!(&eigen(eigen::trsm_c32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -726,7 +739,7 @@ Computing `A^-1` where `A` is a square triangular matrix with dimension `n`.
             &tr_inverse::faer::<c32>(&input_sizes, Parallelism::None),
             &tr_inverse::faer::<c32>(&input_sizes, Parallelism::Rayon(0)),
             &tr_inverse::ndarray::<Cplx32>(&input_sizes),
-            &tr_inverse::nalgebra::<Cplx32>(&input_sizes),
+            ifnalgebra!(&tr_inverse::nalgebra::<Cplx32>(&input_sizes)),
             ifeigen!(&eigen(eigen::trinv_c32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -746,7 +759,7 @@ Factorizing a square matrix with dimension `n` as `L×L.T`, where `L` is lower t
             &cholesky::faer::<c32>(&input_sizes, Parallelism::None),
             &cholesky::faer::<c32>(&input_sizes, Parallelism::Rayon(0)),
             &cholesky::ndarray::<Cplx32>(&input_sizes),
-            &cholesky::nalgebra::<Cplx32>(&input_sizes),
+            ifnalgebra!(&cholesky::nalgebra::<Cplx32>(&input_sizes)),
             ifeigen!(&eigen(eigen::chol_c32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -763,7 +776,7 @@ Factorizing a square matrix with dimension `n` as `P×L×U`, where `P` is a perm
             &partial_piv_lu::faer::<c32>(&input_sizes, Parallelism::None),
             &partial_piv_lu::faer::<c32>(&input_sizes, Parallelism::Rayon(0)),
             &partial_piv_lu::ndarray::<Cplx32>(&input_sizes),
-            &partial_piv_lu::nalgebra::<Cplx32>(&input_sizes),
+            ifnalgebra!(&partial_piv_lu::nalgebra::<Cplx32>(&input_sizes)),
             ifeigen!(&eigen(eigen::plu_c32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -780,7 +793,7 @@ Factorizing a square matrix with dimension `n` as `P×L×U×Q.T`, where `P` and 
             &full_piv_lu::faer::<c32>(&input_sizes, Parallelism::None),
             &full_piv_lu::faer::<c32>(&input_sizes, Parallelism::Rayon(0)),
             &full_piv_lu::ndarray::<Cplx32>(&input_sizes),
-            &full_piv_lu::nalgebra::<Cplx32>(&input_sizes),
+            ifnalgebra!(&full_piv_lu::nalgebra::<Cplx32>(&input_sizes)),
             ifeigen!(&eigen(eigen::flu_c32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -797,7 +810,7 @@ Factorizing a square matrix with dimension `n` as `QR`, where `Q` is unitary and
             &no_piv_qr::faer::<c32>(&input_sizes, Parallelism::None),
             &no_piv_qr::faer::<c32>(&input_sizes, Parallelism::Rayon(0)),
             &no_piv_qr::ndarray::<Cplx32>(&input_sizes),
-            &no_piv_qr::nalgebra::<Cplx32>(&input_sizes),
+            ifnalgebra!(&no_piv_qr::nalgebra::<Cplx32>(&input_sizes)),
             ifeigen!(&eigen(eigen::qr_c32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -814,7 +827,7 @@ Factorizing a square matrix with dimension `n` as `QRP`, where `P` is a permutat
             &col_piv_qr::faer::<c32>(&input_sizes, Parallelism::None),
             &col_piv_qr::faer::<c32>(&input_sizes, Parallelism::Rayon(0)),
             &col_piv_qr::ndarray::<Cplx32>(&input_sizes),
-            &col_piv_qr::nalgebra::<Cplx32>(&input_sizes),
+            ifnalgebra!(&col_piv_qr::nalgebra::<Cplx32>(&input_sizes)),
             ifeigen!(&eigen(eigen::colqr_c32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -834,7 +847,7 @@ Computing the inverse of a square matrix with dimension `n`.
             &inverse::faer::<c32>(&input_sizes, Parallelism::None),
             &inverse::faer::<c32>(&input_sizes, Parallelism::Rayon(0)),
             &inverse::ndarray::<Cplx32>(&input_sizes),
-            &inverse::nalgebra::<Cplx32>(&input_sizes),
+            ifnalgebra!(&inverse::nalgebra::<Cplx32>(&input_sizes)),
             ifeigen!(&eigen(eigen::inverse_c32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -854,7 +867,7 @@ Computing the SVD of a square matrix with dimension `n`.
             &svd::faer::<c32>(&input_sizes, Parallelism::None),
             &svd::faer::<c32>(&input_sizes, Parallelism::Rayon(0)),
             &svd::ndarray::<Cplx32>(&input_sizes),
-            &svd::nalgebra::<Cplx32>(&input_sizes),
+            ifnalgebra!(&svd::nalgebra::<Cplx32>(&input_sizes)),
             ifeigen!(&eigen(eigen::svd_c32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -874,7 +887,7 @@ Computing the SVD of a rectangular matrix with shape `(4096, n)`.
             &rectangular_svd::faer::<c32>(&input_sizes, Parallelism::None),
             &rectangular_svd::faer::<c32>(&input_sizes, Parallelism::Rayon(0)),
             &rectangular_svd::ndarray::<Cplx32>(&input_sizes),
-            &rectangular_svd::nalgebra::<Cplx32>(&input_sizes),
+            ifnalgebra!(&rectangular_svd::nalgebra::<Cplx32>(&input_sizes)),
             ifeigen!(&eigen(eigen::rectangular_svd_c32, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -897,7 +910,7 @@ Multiplication of two square matrices of dimension `n`.
             &gemm::faer::<c64>(&input_sizes, Parallelism::None),
             &gemm::faer::<c64>(&input_sizes, Parallelism::Rayon(0)),
             &gemm::ndarray::<Cplx64>(&input_sizes),
-            &gemm::nalgebra::<Cplx64>(&input_sizes),
+            ifnalgebra!(&gemm::nalgebra::<Cplx64>(&input_sizes)),
             ifeigen!(&eigen(eigen::gemm_c64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -914,7 +927,7 @@ Solving `AX = B` in place where `A` and `B` are two square matrices of dimension
             &trsm::faer::<c64>(&input_sizes, Parallelism::None),
             &trsm::faer::<c64>(&input_sizes, Parallelism::Rayon(0)),
             &trsm::ndarray::<Cplx64>(&input_sizes),
-            &trsm::nalgebra::<Cplx64>(&input_sizes),
+            ifnalgebra!(&trsm::nalgebra::<Cplx64>(&input_sizes)),
             ifeigen!(&eigen(eigen::trsm_c64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -934,7 +947,7 @@ Computing `A^-1` where `A` is a square triangular matrix with dimension `n`.
             &tr_inverse::faer::<c64>(&input_sizes, Parallelism::None),
             &tr_inverse::faer::<c64>(&input_sizes, Parallelism::Rayon(0)),
             &tr_inverse::ndarray::<Cplx64>(&input_sizes),
-            &tr_inverse::nalgebra::<Cplx64>(&input_sizes),
+            ifnalgebra!(&tr_inverse::nalgebra::<Cplx64>(&input_sizes)),
             ifeigen!(&eigen(eigen::trinv_c64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -954,7 +967,7 @@ Factorizing a square matrix with dimension `n` as `L×L.T`, where `L` is lower t
             &cholesky::faer::<c64>(&input_sizes, Parallelism::None),
             &cholesky::faer::<c64>(&input_sizes, Parallelism::Rayon(0)),
             &cholesky::ndarray::<Cplx64>(&input_sizes),
-            &cholesky::nalgebra::<Cplx64>(&input_sizes),
+            ifnalgebra!(&cholesky::nalgebra::<Cplx64>(&input_sizes)),
             ifeigen!(&eigen(eigen::chol_c64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -971,7 +984,7 @@ Factorizing a square matrix with dimension `n` as `P×L×U`, where `P` is a perm
             &partial_piv_lu::faer::<c64>(&input_sizes, Parallelism::None),
             &partial_piv_lu::faer::<c64>(&input_sizes, Parallelism::Rayon(0)),
             &partial_piv_lu::ndarray::<Cplx64>(&input_sizes),
-            &partial_piv_lu::nalgebra::<Cplx64>(&input_sizes),
+            ifnalgebra!(&partial_piv_lu::nalgebra::<Cplx64>(&input_sizes)),
             ifeigen!(&eigen(eigen::plu_c64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -988,7 +1001,7 @@ Factorizing a square matrix with dimension `n` as `P×L×U×Q.T`, where `P` and 
             &full_piv_lu::faer::<c64>(&input_sizes, Parallelism::None),
             &full_piv_lu::faer::<c64>(&input_sizes, Parallelism::Rayon(0)),
             &full_piv_lu::ndarray::<Cplx64>(&input_sizes),
-            &full_piv_lu::nalgebra::<Cplx64>(&input_sizes),
+            ifnalgebra!(&full_piv_lu::nalgebra::<Cplx64>(&input_sizes)),
             ifeigen!(&eigen(eigen::flu_c64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -1005,7 +1018,7 @@ Factorizing a square matrix with dimension `n` as `QR`, where `Q` is unitary and
             &no_piv_qr::faer::<c64>(&input_sizes, Parallelism::None),
             &no_piv_qr::faer::<c64>(&input_sizes, Parallelism::Rayon(0)),
             &no_piv_qr::ndarray::<Cplx64>(&input_sizes),
-            &no_piv_qr::nalgebra::<Cplx64>(&input_sizes),
+            ifnalgebra!(&no_piv_qr::nalgebra::<Cplx64>(&input_sizes)),
             ifeigen!(&eigen(eigen::qr_c64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -1022,7 +1035,7 @@ Factorizing a square matrix with dimension `n` as `QRP`, where `P` is a permutat
             &col_piv_qr::faer::<c64>(&input_sizes, Parallelism::None),
             &col_piv_qr::faer::<c64>(&input_sizes, Parallelism::Rayon(0)),
             &col_piv_qr::ndarray::<Cplx64>(&input_sizes),
-            &col_piv_qr::nalgebra::<Cplx64>(&input_sizes),
+            ifnalgebra!(&col_piv_qr::nalgebra::<Cplx64>(&input_sizes)),
             ifeigen!(&eigen(eigen::colqr_c64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -1042,7 +1055,7 @@ Computing the inverse of a square matrix with dimension `n`.
             &inverse::faer::<c64>(&input_sizes, Parallelism::None),
             &inverse::faer::<c64>(&input_sizes, Parallelism::Rayon(0)),
             &inverse::ndarray::<Cplx64>(&input_sizes),
-            &inverse::nalgebra::<Cplx64>(&input_sizes),
+            ifnalgebra!(&inverse::nalgebra::<Cplx64>(&input_sizes)),
             ifeigen!(&eigen(eigen::inverse_c64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -1062,7 +1075,7 @@ Computing the SVD of a square matrix with dimension `n`.
             &svd::faer::<c64>(&input_sizes, Parallelism::None),
             &svd::faer::<c64>(&input_sizes, Parallelism::Rayon(0)),
             &svd::ndarray::<Cplx64>(&input_sizes),
-            &svd::nalgebra::<Cplx64>(&input_sizes),
+            ifnalgebra!(&svd::nalgebra::<Cplx64>(&input_sizes)),
             ifeigen!(&eigen(eigen::svd_c64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;
@@ -1082,7 +1095,7 @@ Computing the SVD of a rectangular matrix with shape `(4096, n)`.
             &rectangular_svd::faer::<c64>(&input_sizes, Parallelism::None),
             &rectangular_svd::faer::<c64>(&input_sizes, Parallelism::Rayon(0)),
             &rectangular_svd::ndarray::<Cplx64>(&input_sizes),
-            &rectangular_svd::nalgebra::<Cplx64>(&input_sizes),
+            ifnalgebra!(&rectangular_svd::nalgebra::<Cplx64>(&input_sizes)),
             ifeigen!(&eigen(eigen::rectangular_svd_c64, &input_sizes)),
         )?;
         printwriteln!(file, "```")?;

--- a/faer-svd/benches/bench.rs
+++ b/faer-svd/benches/bench.rs
@@ -23,9 +23,9 @@ pub fn bidiag(c: &mut Criterion) {
         (4096, 4096),
     ] {
         c.bench_function(&format!("faer-st-bidiag-{m}x{n}"), |b| {
-            let mut mat = Mat::with_dims(|_, _| random::<f64>(), m, n);
-            let mut householder_left = Mat::with_dims(|_, _| random::<f64>(), n, 1);
-            let mut householder_right = Mat::with_dims(|_, _| random::<f64>(), n, 1);
+            let mut mat = Mat::with_dims(m, n, |_, _| random::<f64>());
+            let mut householder_left = Mat::with_dims(n, 1, |_, _| random::<f64>());
+            let mut householder_right = Mat::with_dims(n, 1, |_, _| random::<f64>());
 
             let mut mem = GlobalMemBuffer::new(
                 faer_svd::bidiag::bidiagonalize_in_place_req::<f64>(m, n, Parallelism::None)
@@ -45,9 +45,9 @@ pub fn bidiag(c: &mut Criterion) {
         });
 
         c.bench_function(&format!("faer-mt-bidiag-{m}x{n}"), |b| {
-            let mut mat = Mat::with_dims(|_, _| random::<f64>(), m, n);
-            let mut householder_left = Mat::with_dims(|_, _| random::<f64>(), n, 1);
-            let mut householder_right = Mat::with_dims(|_, _| random::<f64>(), n, 1);
+            let mut mat = Mat::with_dims(m, n, |_, _| random::<f64>());
+            let mut householder_left = Mat::with_dims(n, 1, |_, _| random::<f64>());
+            let mut householder_right = Mat::with_dims(n, 1, |_, _| random::<f64>());
 
             let mut mem = GlobalMemBuffer::new(
                 faer_svd::bidiag::bidiagonalize_in_place_req::<f64>(m, n, Parallelism::Rayon(0))
@@ -164,7 +164,7 @@ fn real_svd(c: &mut Criterion) {
         (2048, 2048),
         (4096, 4096),
     ] {
-        let mat = Mat::with_dims(|_, _| rand::random::<f64>(), m, n);
+        let mat = Mat::with_dims(m, n, |_, _| rand::random::<f64>());
         let mat = mat.as_ref();
 
         let size = m.min(n);


### PR DESCRIPTION
Allows to disable eigen or nalgebra at compile time.
eigen takes comparably long to compile and nalgebra cause benchmarking for larger n to become slow.
I use it for a couple of benchmarks, but feel free to close if you don't need it upstream.
