### PR TITLE
Changed to using the is_nan() method

### DIFF
--- a/faer-core/src/lib.rs
+++ b/faer-core/src/lib.rs
@@ -1044,7 +1044,7 @@ impl ComplexField for c32 {
     #[inline(always)]
     fn inv(&self) -> Self {
         let inf = Self::Real::zero().inv();
-        if self != self {
+        if self.is_nan() {
             // NAN
             Self::nan()
         } else if *self == Self::zero() {
@@ -1292,7 +1292,7 @@ impl ComplexField for c64 {
     #[inline(always)]
     fn inv(&self) -> Self {
         let inf = Self::Real::zero().inv();
-        if self != self {
+        if self.is_nan() {
             // NAN
             Self::nan()
         } else if *self == Self::zero() {
@@ -1541,7 +1541,7 @@ impl<E: RealField> ComplexField for Complex<E> {
     #[inline(always)]
     fn inv(&self) -> Self {
         let inf = Self::Real::zero().inv();
-        if self != self {
+        if self.is_nan() {
             // NAN
             Self::nan()
         } else if *self == Self::zero() {


### PR DESCRIPTION
Changed the possibly misleading / confusing boolean check for checking if a variable is NaN from 'self != self' to 'self.is_nan()' for inv functions for ComplexField for c32, c64, and Complex<E>. Under the hood, is_nan() is still using the 'self != self' check, however this should now only appear in that definition, and should cause less confusion. 