### PR TITLE
Matrix Addition and Subtraction

### DIFF
--- a/faer-core/Cargo.toml
+++ b/faer-core/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["math", "matrix", "linear-algebra"]
 gemm = { version = "0.15", default-features = false }
 aligned-vec = "0.5"
 seq-macro = "0.3"
+paste =  "1.0"
 
 pulp = { workspace = true, default-features = false }
 coe-rs = { workspace = true }

--- a/faer-core/src/add.rs
+++ b/faer-core/src/add.rs
@@ -152,6 +152,22 @@ mod test {
     }
 
     #[test]
+    #[should_panic]
+    fn test_adding_matrices_of_different_sizes_should_panic() {
+        let A = mat![[1.0, 2.0], [3.0, 4.0]];
+        let B = mat![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]];
+        _ = A + B;
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_subtracting_two_matrices_of_different_sizes_should_panic() {
+        let A = mat![[1.0, 2.0], [3.0, 4.0]];
+        let B = mat![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]];
+        _ = A - B;
+    }
+
+    #[test]
     fn test_add() {
         let (A, B) = matrices();
 
@@ -159,6 +175,8 @@ mod test {
 
         assert_matrix_approx_eq(A.as_ref() + B.as_ref(), &expected);
         assert_matrix_approx_eq(&A + &B, &expected);
+        assert_matrix_approx_eq(A.as_ref() + &B, &expected);
+        assert_matrix_approx_eq(&A + B.as_ref(), &expected);
         assert_matrix_approx_eq(A.as_ref() + B.clone(), &expected);
         assert_matrix_approx_eq(&A + B.clone(), &expected);
         assert_matrix_approx_eq(A.clone() + B.as_ref(), &expected);
@@ -173,12 +191,13 @@ mod test {
         let expected = mat![[10.7, -11.6], [-6.4, 8.4], [0.8, -3.1],];
 
         assert_matrix_approx_eq(A.as_ref() - B.as_ref(), &expected);
+        assert_matrix_approx_eq(&A - &B, &expected);
+        assert_matrix_approx_eq(A.as_ref() - &B, &expected);
         assert_matrix_approx_eq(&A - B.as_ref(), &expected);
         assert_matrix_approx_eq(A.as_ref() - B.clone(), &expected);
         assert_matrix_approx_eq(&A - B.clone(), &expected);
         assert_matrix_approx_eq(A.clone() - B.as_ref(), &expected);
         assert_matrix_approx_eq(A.clone() - &B, &expected);
-        assert_matrix_approx_eq(&A - &B, &expected);
         assert_matrix_approx_eq(A - B, &expected);
     }
 

--- a/faer-core/src/add.rs
+++ b/faer-core/src/add.rs
@@ -52,10 +52,9 @@ where
 macro_rules! impl_binary_op {
     ($Op:ty) => {
         paste::paste! {
-            impl<'a,T> $Op<MatRef<'_,T>> for Mat<T>
+            impl<T> $Op<MatRef<'_,T>> for Mat<T>
             where
                 T: ComplexField,
-                T::Unit: ComplexField,
             {
                 type Output = Mat<T>;
                 fn [<$Op:lower>](self, rhs: MatRef<'_,T>) -> Self::Output {
@@ -63,10 +62,9 @@ macro_rules! impl_binary_op {
                 }
             }
 
-            impl<'a,T> $Op<Mat<T>> for MatRef<'_,T>
+            impl<T> $Op<Mat<T>> for MatRef<'_,T>
             where
                 T: ComplexField,
-                T::Unit: ComplexField,
             {
                 type Output = Mat<T>;
                 fn [<$Op:lower>](self, rhs: Mat<T>) -> Self::Output {
@@ -74,13 +72,62 @@ macro_rules! impl_binary_op {
                 }
             }
 
-            impl<'a,T> $Op<Mat<T>> for Mat<T>
+            impl<T> $Op<Mat<T>> for Mat<T>
             where
                 T: ComplexField,
-                T::Unit: ComplexField,
             {
                 type Output = Mat<T>;
                 fn [<$Op:lower>](self, rhs: Mat<T>) -> Self::Output {
+                    self.as_ref().[<$Op:lower>] (rhs.as_ref())
+                }
+            }
+
+            impl<T> $Op<&Mat<T>> for MatRef<'_,T>
+            where
+                T: ComplexField,
+            {
+                type Output = Mat<T>;
+                fn [<$Op:lower>](self, rhs: &Mat<T>) -> Self::Output {
+                    self.[<$Op:lower>] (rhs.as_ref())
+                }
+            }
+
+            impl<T> $Op<MatRef<'_,T>> for &Mat<T>
+            where
+                T: ComplexField,
+            {
+                type Output = Mat<T>;
+                fn [<$Op:lower>](self, rhs: MatRef<'_,T>) -> Self::Output {
+                    self.as_ref().[<$Op:lower>] (rhs)
+                }
+            }
+
+            impl<T> $Op<&Mat<T>> for &'_ Mat<T>
+            where
+                T: ComplexField,
+            {
+                type Output = Mat<T>;
+                fn [<$Op:lower>](self, rhs: &Mat<T>) -> Self::Output {
+                    self.as_ref().[<$Op:lower>] (rhs.as_ref())
+                }
+            }
+
+            impl<T> $Op<Mat<T>> for &Mat<T>
+            where
+                T: ComplexField,
+            {
+                type Output = Mat<T>;
+                fn [<$Op:lower>](self, rhs: Mat<T>) -> Self::Output {
+                    self.as_ref().[<$Op:lower>] (rhs.as_ref())
+                }
+            }
+
+            impl<T> $Op<&Mat<T>> for Mat<T>
+            where
+                T: ComplexField,
+            {
+                type Output = Mat<T>;
+                fn [<$Op:lower>](self, rhs: &Mat<T>) -> Self::Output {
                     self.as_ref().[<$Op:lower>] (rhs.as_ref())
                 }
             }
@@ -111,8 +158,11 @@ mod test {
         let expected = mat![[-5.1, 5.0], [3.0, 2.0], [8.4, -13.5],];
 
         assert_matrix_approx_eq(A.as_ref() + B.as_ref(), &expected);
+        assert_matrix_approx_eq(&A + &B, &expected);
         assert_matrix_approx_eq(A.as_ref() + B.clone(), &expected);
+        assert_matrix_approx_eq(&A + B.clone(), &expected);
         assert_matrix_approx_eq(A.clone() + B.as_ref(), &expected);
+        assert_matrix_approx_eq(A.clone() + &B, &expected);
         assert_matrix_approx_eq(A + B, &expected);
     }
 
@@ -123,8 +173,12 @@ mod test {
         let expected = mat![[10.7, -11.6], [-6.4, 8.4], [0.8, -3.1],];
 
         assert_matrix_approx_eq(A.as_ref() - B.as_ref(), &expected);
+        assert_matrix_approx_eq(&A - B.as_ref(), &expected);
         assert_matrix_approx_eq(A.as_ref() - B.clone(), &expected);
+        assert_matrix_approx_eq(&A - B.clone(), &expected);
         assert_matrix_approx_eq(A.clone() - B.as_ref(), &expected);
+        assert_matrix_approx_eq(A.clone() - &B, &expected);
+        assert_matrix_approx_eq(&A - &B, &expected);
         assert_matrix_approx_eq(A - B, &expected);
     }
 

--- a/faer-core/src/add.rs
+++ b/faer-core/src/add.rs
@@ -1,5 +1,7 @@
+//! addition and subtraction of matrices
+
 use crate::{ComplexField, Conjugate, Entity, Mat, MatRef};
-use std::ops::{Add, AddAssign, Sub};
+use core::ops::{Add, AddAssign, Sub};
 
 // add two matrices together
 impl<'a, T> Add<MatRef<'_, T>> for MatRef<'a, T>
@@ -8,6 +10,9 @@ where
     T::Unit: ComplexField,
 {
     type Output = Mat<T>;
+    /// create a new matrix corresponding to the addition of `rhs` to `self`.
+    /// # Panics
+    /// Panics if the matrix dimensions do not match.
     fn add(self, rhs: MatRef<'_, T>) -> Self::Output {
         assert_eq!(
             (self.nrows(), self.ncols()),
@@ -20,13 +25,15 @@ where
     }
 }
 
-// subtract two matrices
 impl<'a, T> Sub<MatRef<'_, T>> for MatRef<'a, T>
 where
     T: ComplexField,
     T::Unit: ComplexField,
 {
     type Output = Mat<T>;
+    /// create a new matrix corresponding to the subtraction of `rhs` from `self`.
+    /// # Panics
+    /// Panics if the matrix dimensions do not match.
     fn sub(self, rhs: MatRef<'_, T>) -> Self::Output {
         assert_eq!(
             (self.nrows(), self.ncols()),

--- a/faer-core/src/add.rs
+++ b/faer-core/src/add.rs
@@ -7,7 +7,6 @@ use core::ops::{Add, Sub};
 impl<'a, T> Add<MatRef<'_, T>> for MatRef<'a, T>
 where
     T: ComplexField,
-    T::Unit: ComplexField,
 {
     type Output = Mat<T>;
     /// create a new matrix corresponding to the addition of `rhs` to `self`.
@@ -28,7 +27,6 @@ where
 impl<'a, T> Sub<MatRef<'_, T>> for MatRef<'a, T>
 where
     T: ComplexField,
-    T::Unit: ComplexField,
 {
     type Output = Mat<T>;
     /// create a new matrix corresponding to the subtraction of `rhs` from `self`.

--- a/faer-core/src/add.rs
+++ b/faer-core/src/add.rs
@@ -1,0 +1,40 @@
+use crate::{ComplexField, Conjugate, Entity, Mat, MatRef};
+use std::ops::{Add, AddAssign, Sub};
+
+// add two matrices together
+impl<'a, T> Add<MatRef<'_, T>> for MatRef<'a, T>
+where
+    T: ComplexField,
+    T::Unit: ComplexField,
+{
+    type Output = Mat<T>;
+    fn add(self, rhs: MatRef<'_, T>) -> Self::Output {
+        assert_eq!(
+            (self.nrows(), self.ncols()),
+            (rhs.nrows(), rhs.ncols()),
+            "Matrix dimensions must match"
+        );
+        Self::Output::with_dims(self.nrows(), self.ncols(), |i, j| {
+            self.read(i, j).add(&rhs.read(i, j))
+        })
+    }
+}
+
+// subtract two matrices
+impl<'a, T> Sub<MatRef<'_, T>> for MatRef<'a, T>
+where
+    T: ComplexField,
+    T::Unit: ComplexField,
+{
+    type Output = Mat<T>;
+    fn sub(self, rhs: MatRef<'_, T>) -> Self::Output {
+        assert_eq!(
+            (self.nrows(), self.ncols()),
+            (rhs.nrows(), rhs.ncols()),
+            "Matrix dimensions must match"
+        );
+        Self::Output::with_dims(self.nrows(), self.ncols(), |i, j| {
+            self.read(i, j).sub(&rhs.read(i, j))
+        })
+    }
+}

--- a/faer-core/src/add.rs
+++ b/faer-core/src/add.rs
@@ -1,7 +1,7 @@
 //! addition and subtraction of matrices
 
-use crate::{ComplexField, Conjugate, Entity, Mat, MatRef};
-use core::ops::{Add, AddAssign, Sub};
+use crate::{ComplexField, Mat, MatRef};
+use core::ops::{Add, Sub};
 
 // add two matrices together
 impl<'a, T> Add<MatRef<'_, T>> for MatRef<'a, T>
@@ -43,5 +43,100 @@ where
         Self::Output::with_dims(self.nrows(), self.ncols(), |i, j| {
             self.read(i, j).sub(&rhs.read(i, j))
         })
+    }
+}
+
+// implement the add trait for cases where one of the operands is
+// an owned matrix by deferring to the case where both are references
+// @todo: this will allocate even if one of the operands could be reuse
+// and in future we should consider adding an efficient add- and sub-assign
+// implementations that are used instead as backends
+macro_rules! impl_binary_op {
+    ($Op:ty) => {
+        paste::paste! {
+            impl<'a,T> $Op<MatRef<'_,T>> for Mat<T>
+            where
+                T: ComplexField,
+                T::Unit: ComplexField,
+            {
+                type Output = Mat<T>;
+                fn [<$Op:lower>](self, rhs: MatRef<'_,T>) -> Self::Output {
+                    self.as_ref().[<$Op:lower>] (rhs)
+                }
+            }
+
+            impl<'a,T> $Op<Mat<T>> for MatRef<'_,T>
+            where
+                T: ComplexField,
+                T::Unit: ComplexField,
+            {
+                type Output = Mat<T>;
+                fn [<$Op:lower>](self, rhs: Mat<T>) -> Self::Output {
+                    self.[<$Op:lower>] (rhs.as_ref())
+                }
+            }
+
+            impl<'a,T> $Op<Mat<T>> for Mat<T>
+            where
+                T: ComplexField,
+                T::Unit: ComplexField,
+            {
+                type Output = Mat<T>;
+                fn [<$Op:lower>](self, rhs: Mat<T>) -> Self::Output {
+                    self.as_ref().[<$Op:lower>] (rhs.as_ref())
+                }
+            }
+        }
+    };
+}
+
+impl_binary_op!(Add);
+impl_binary_op!(Sub);
+
+#[cfg(test)]
+#[allow(non_snake_case)]
+mod test {
+    use crate::{mat, Mat};
+    use assert_approx_eq::assert_approx_eq;
+
+    fn matrices() -> (Mat<f64>, Mat<f64>) {
+        let A = mat![[2.8, -3.3], [-1.7, 5.2], [4.6, -8.3],];
+
+        let B = mat![[-7.9, 8.3], [4.7, -3.2], [3.8, -5.2],];
+        (A, B)
+    }
+
+    #[test]
+    fn test_add() {
+        let (A, B) = matrices();
+
+        let expected = mat![[-5.1, 5.0], [3.0, 2.0], [8.4, -13.5],];
+
+        assert_matrix_approx_eq(A.as_ref() + B.as_ref(), &expected);
+        assert_matrix_approx_eq(A.as_ref() + B.clone(), &expected);
+        assert_matrix_approx_eq(A.clone() + B.as_ref(), &expected);
+        assert_matrix_approx_eq(A + B, &expected);
+    }
+
+    #[test]
+    fn test_sub() {
+        let (A, B) = matrices();
+
+        let expected = mat![[10.7, -11.6], [-6.4, 8.4], [0.8, -3.1],];
+
+        assert_matrix_approx_eq(A.as_ref() - B.as_ref(), &expected);
+        assert_matrix_approx_eq(A.as_ref() - B.clone(), &expected);
+        assert_matrix_approx_eq(A.clone() - B.as_ref(), &expected);
+        assert_matrix_approx_eq(A - B, &expected);
+    }
+
+    fn assert_matrix_approx_eq(given: Mat<f64>, expected: &Mat<f64>) {
+        assert_eq!(given.nrows(), expected.nrows());
+        assert_eq!(given.ncols(), expected.ncols());
+        for i in 0..given.nrows() {
+            for j in 0..given.ncols() {
+                assert_approx_eq!(given.read(i, j), expected.read(i, j));
+            }
+        }
     }
 }

--- a/faer-core/src/lib.rs
+++ b/faer-core/src/lib.rs
@@ -18,12 +18,13 @@ pub mod householder;
 #[doc(hidden)]
 pub mod jacobi;
 
-pub mod add;
 pub mod inverse;
 pub mod mul;
 pub mod permutation;
 pub mod solve;
 pub mod zip;
+
+mod add;
 
 #[doc(hidden)]
 pub mod simd;

--- a/faer-core/src/lib.rs
+++ b/faer-core/src/lib.rs
@@ -24,7 +24,7 @@ pub mod permutation;
 pub mod solve;
 pub mod zip;
 
-mod add;
+pub mod add;
 
 #[doc(hidden)]
 pub mod simd;

--- a/faer-core/src/lib.rs
+++ b/faer-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod householder;
 #[doc(hidden)]
 pub mod jacobi;
 
+pub mod add;
 pub mod inverse;
 pub mod mul;
 pub mod permutation;


### PR DESCRIPTION
~**DRAFT**~ (not a draft anymore)

Hey, this is a draft PR aiming to address https://github.com/sarah-ek/faer-rs/issues/41.

Am I on the right track here and using the entity trait the way you want it to be used? If so I can proceed with the implementation.

One more question: I saw that you based the 0.7 version of the addition and subtraction on the matrix references, which is very elegant because we can reuse it to implement addition and subtraction for the owned matrix types as well. However, I was wondering if it could be beneficial to provide in-place addition for Mat + MatRef where the owned matrix storage is just reused. Do you think this is worthwile or are you not concerned with extra allocations? The resize_with api is _almost_ what I need, but it wont't do because I would need to mutably and immutable borrow self to perform the addition. Would you be okay with me addin a map_with function that mutates the elements of a matrix in place? I could base my in-place addition on that function then, but I wanted to know how you think about this...