### PR TITLE
Remomve column names from function signature

### DIFF
--- a/faer/Cargo.toml
+++ b/faer/Cargo.toml
@@ -24,7 +24,7 @@ matrixcompare = "0.3"
 dbgf = "0.1.0"
 nalgebra = { version = "0.32", optional = true, default-features = false }
 ndarray = { version = "0.15", optional = true, default-features = false }
-polars = { version = "0.33", optional = true, default-features = false }
+polars = { version = "0.33", optional = true, features =  [ "lazy" ] }
 
 [features]
 default = ["std"]
@@ -47,7 +47,6 @@ nightly = [
 nalgebra = ["dep:nalgebra"]
 ndarray = ["dep:ndarray"]
 polars = ["dep:polars"]
-polars-lazy = ["polars/lazy"]
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
@@ -62,7 +61,7 @@ required-features = ["nalgebra", "ndarray"]
 
 [[example]]
 name = "polars"
-required-features = ["polars", "polars-lazy"]
+required-features = ["polars" ]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/faer/examples/polars.rs
+++ b/faer/examples/polars.rs
@@ -3,26 +3,7 @@ use polars::prelude::*;
 
 fn main() -> PolarsResult<()> {
     let directory = "./faer/examples/";
-
-    for (filename, cols) in [
-        (
-            "diabetes_data_raw.parquet",
-            [
-                "age", "sex", "bmi", "bp", "s1", "s2", "s3", "s4", "s5", "s6",
-            ]
-            .as_slice(),
-        ),
-        (
-            "iris.parquet",
-            [
-                "sepal length (cm)",
-                "sepal width (cm)",
-                "petal length (cm)",
-                "petal width (cm)",
-            ]
-            .as_slice(),
-        ),
-    ] {
+    for filename in ["diabetes_data_raw.parquet", "iris.parquet"] {
         dbg!(filename);
 
         let data = LazyFrame::scan_parquet(
@@ -38,7 +19,7 @@ fn main() -> PolarsResult<()> {
                 use_statistics: true,
             },
         )
-        .and_then(|df| polars_to_faer_f64(df, cols, 0.0))
+        .and_then(|lf| polars_to_faer_f64(lf))
         .unwrap();
         dbgf!("6.2?", data);
     }

--- a/faer/src/lib.rs
+++ b/faer/src/lib.rs
@@ -2771,13 +2771,11 @@ pub mod polars {
             #[cfg_attr(docsrs, doc(cfg(feature = "polars")))]
             pub fn $fn_name(
                 frame: impl Frame,
-                // null_value: $ty,
             ) -> PolarsResult<Mat<$ty>> {
                 use core::{iter::zip, mem::MaybeUninit};
 
                 fn implementation(
                     lf: LazyFrame,
-                    // dtype: $ty,
                 ) -> PolarsResult<Mat<$ty>> {
                     let df = lf
                         .select(&[col("*").cast(DataType::$dtype)])


### PR DESCRIPTION
Fixes #65

In the process, there was no longer a reason to split out `DataFrame` and `LazyFrame` functionality and the function now requires a `polars::LazyFrame`.