### PR TITLE
add serde feature

### DIFF
--- a/faer-libs/Cargo.toml
+++ b/faer-libs/Cargo.toml
@@ -29,6 +29,7 @@ bytemuck = { version = "1", default-features = false }
 
 rand = { version = "0.8", default-features = false }
 rayon = "1"
+serde = { version = "1", features = ["derive"] }
 assert2 = "0.3"
 equator = "0.1.8"
 log = { version = "0.4", default-features = false }

--- a/faer-libs/faer-core/Cargo.toml
+++ b/faer-libs/faer-core/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.67.0"
 faer-entity = { workspace = true, default-features = false }
 
 seq-macro = "0.3"
-paste =  "1.0"
+paste = "1.0"
 
 coe-rs = { workspace = true }
 reborrow = { workspace = true }
@@ -29,12 +29,13 @@ bytemuck = { workspace = true }
 
 rand = { workspace = true, optional = true, default-features = false }
 rayon = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
 equator = { workspace = true }
 log = { workspace = true, optional = true, default-features = false }
 matrixcompare-core = { version = "0.1.0", optional = true }
 
 [features]
-default = ["std", "rayon"]
+default = ["std", "rayon", "serde"]
 std = [
   "faer-entity/std",
   "gemm/std",
@@ -43,17 +44,10 @@ std = [
   "num-traits/std",
   "num-complex/std",
 ]
-rayon = [
-  "std",
-  "gemm/rayon",
-  "dep:rayon",
-]
-nightly = [
-  "faer-entity/nightly",
-  "gemm/nightly",
-  "pulp/nightly",
-]
+rayon = ["std", "gemm/rayon", "dep:rayon"]
+nightly = ["faer-entity/nightly", "gemm/nightly", "pulp/nightly"]
 perf-warn = ["log"]
+serde = ["dep:serde"]
 
 [dev-dependencies]
 criterion = "0.5"
@@ -61,6 +55,7 @@ rand = "0.8.5"
 nalgebra = "0.32.3"
 assert_approx_eq = "1.1.0"
 dbgf = "0.1.1"
+serde_test = "1.0.176"
 
 [[bench]]
 name = "bench"

--- a/faer-libs/faer-core/src/lib.rs
+++ b/faer-libs/faer-core/src/lib.rs
@@ -205,6 +205,8 @@ pub mod solve;
 
 pub mod matrix_ops;
 
+#[cfg(feature = "serde")]
+pub mod serde_impl;
 pub mod sparse;
 
 /// Thin wrapper used for scalar multiplication of a matrix by a scalar value.

--- a/faer-libs/faer-core/src/serde_impl.rs
+++ b/faer-libs/faer-core/src/serde_impl.rs
@@ -1,0 +1,138 @@
+//! Serde implementations for Mat
+
+use faer_entity::Entity;
+use serde::{Deserialize, Serialize, Serializer};
+
+use crate::Mat;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
+struct SerdeMat<E: Entity> {
+    col_length: usize,
+    data: Vec<E>,
+}
+
+impl<E: Entity> Into<Mat<E>> for SerdeMat<E> {
+    fn into(self) -> Mat<E> {
+        let row_length = self.data.len() / self.col_length;
+        Mat::from_fn(row_length, self.col_length, |i, j| {
+            self.data[j + (i * self.col_length)]
+        })
+    }
+}
+
+impl<E: Entity> Into<SerdeMat<E>> for &Mat<E> {
+    fn into(self) -> SerdeMat<E> {
+        let mut data = Vec::with_capacity(self.nrows() * self.ncols());
+        for i in 0..self.nrows() {
+            for j in 0..self.ncols() {
+                data.push(self.read(i, j));
+            }
+        }
+
+        SerdeMat {
+            col_length: self.ncols(),
+            data,
+        }
+    }
+}
+
+impl<E: Entity> Serialize for Mat<E>
+where
+    E: Serialize,
+{
+    fn serialize<S>(&self, s: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+    where
+        S: Serializer,
+    {
+        let mat: SerdeMat<E> = self.into();
+        mat.serialize(s)
+    }
+}
+
+impl<'a, E: Entity> Deserialize<'a> for Mat<E>
+where
+    E: Deserialize<'a>,
+{
+    fn deserialize<D>(d: D) -> Result<Self, <D as serde::Deserializer<'a>>::Error>
+    where
+        D: serde::Deserializer<'a>,
+    {
+        let mat: SerdeMat<E> = SerdeMat::<E>::deserialize(d)?;
+        if mat.data.len() % mat.col_length != 0 {
+            return Err(serde::de::Error::custom(
+                "serialized matrix is now valid as col_length isnt a divisor of the length of the data",
+            ));
+        }
+        Ok(mat.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_test::{assert_de_tokens_error, assert_tokens, Token};
+    #[test]
+    fn mat_to_serde_mat_and_back_again() {
+        let mat = Mat::from_fn(3, 4, |i, j| (i + (j * 10)) as f64);
+        let serde_mat: SerdeMat<f64> = (&mat).into();
+        println!("{:?}", serde_mat);
+        let mat_again: Mat<f64> = serde_mat.into();
+        assert_eq!(mat_again, mat);
+    }
+
+    #[test]
+    fn mat_serialization() {
+        let mat = Mat::from_fn(3, 4, |i, j| (i + (j * 10)) as f64);
+        assert_tokens(
+            &mat,
+            &[
+                Token::Struct {
+                    len: 2,
+                    name: "SerdeMat",
+                },
+                Token::Str("col_length"),
+                Token::U64(4),
+                Token::Str("data"),
+                Token::Seq { len: Some(12) },
+                Token::F64(0.0),
+                Token::F64(10.0),
+                Token::F64(20.0),
+                Token::F64(30.0),
+                Token::F64(1.0),
+                Token::F64(11.0),
+                Token::F64(21.0),
+                Token::F64(31.0),
+                Token::F64(2.0),
+                Token::F64(12.0),
+                Token::F64(22.0),
+                Token::F64(32.0),
+                Token::SeqEnd,
+                Token::StructEnd,
+            ],
+        )
+    }
+
+    #[test]
+    fn deserialization_can_fail() {
+        assert_de_tokens_error::<Mat<f64>>(
+            &[
+                Token::Struct {
+                    len: 2,
+                    name: "SerdeMat",
+                },
+                Token::Str("col_length"),
+                Token::U64(3),
+                Token::Str("data"),
+                Token::Seq { len: Some(12) },
+                Token::F64(0.0),
+                Token::F64(1.0),
+                Token::F64(2.0),
+                Token::F64(3.0),
+                Token::SeqEnd,
+                Token::StructEnd,
+            ],
+            "serialized matrix is now valid as col_length isnt a divisor of the length of the data",
+        )
+    }
+}

--- a/faer-libs/faer-core/src/serde_impl.rs
+++ b/faer-libs/faer-core/src/serde_impl.rs
@@ -1,41 +1,15 @@
 //! Serde implementations for Mat
 
+use core::marker::PhantomData;
+
 use faer_entity::Entity;
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{
+    de::{DeserializeSeed, SeqAccess, Visitor},
+    ser::{SerializeSeq, SerializeStruct},
+    Deserialize, Serialize, Serializer,
+};
 
 use crate::Mat;
-
-#[derive(Debug, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
-struct SerdeMat<E: Entity> {
-    col_length: usize,
-    data: Vec<E>,
-}
-
-impl<E: Entity> Into<Mat<E>> for SerdeMat<E> {
-    fn into(self) -> Mat<E> {
-        let row_length = self.data.len() / self.col_length;
-        Mat::from_fn(row_length, self.col_length, |i, j| {
-            self.data[j + (i * self.col_length)]
-        })
-    }
-}
-
-impl<E: Entity> Into<SerdeMat<E>> for &Mat<E> {
-    fn into(self) -> SerdeMat<E> {
-        let mut data = Vec::with_capacity(self.nrows() * self.ncols());
-        for i in 0..self.nrows() {
-            for j in 0..self.ncols() {
-                data.push(self.read(i, j));
-            }
-        }
-
-        SerdeMat {
-            col_length: self.ncols(),
-            data,
-        }
-    }
-}
 
 impl<E: Entity> Serialize for Mat<E>
 where
@@ -45,8 +19,31 @@ where
     where
         S: Serializer,
     {
-        let mat: SerdeMat<E> = self.into();
-        mat.serialize(s)
+        struct MatSequenceSerializer<'a, E: Entity>(&'a Mat<E>);
+
+        impl<'a, E: Entity> Serialize for MatSequenceSerializer<'a, E>
+        where
+            E: Serialize,
+        {
+            fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                let mut seq = s.serialize_seq(Some(self.0.nrows() * self.0.ncols()))?;
+                for i in 0..self.0.nrows() {
+                    for j in 0..self.0.ncols() {
+                        seq.serialize_element(&self.0.read(i, j))?;
+                    }
+                }
+                seq.end()
+            }
+        }
+
+        let mut structure = s.serialize_struct("Mat", 3)?;
+        structure.serialize_field("nrows", &self.nrows())?;
+        structure.serialize_field("ncols", &self.ncols())?;
+        structure.serialize_field("data", &MatSequenceSerializer(self))?;
+        structure.end()
     }
 }
 
@@ -58,13 +55,154 @@ where
     where
         D: serde::Deserializer<'a>,
     {
-        let mat: SerdeMat<E> = SerdeMat::<E>::deserialize(d)?;
-        if mat.data.len() % mat.col_length != 0 {
-            return Err(serde::de::Error::custom(
-                "serialized matrix is now valid as col_length isnt a divisor of the length of the data",
-            ));
+        #[derive(Deserialize)]
+        #[serde(field_identifier, rename_all = "lowercase")]
+        enum Field {
+            Nrows,
+            Ncols,
+            Data,
         }
-        Ok(mat.into())
+        const FIELDS: &'static [&'static str] = &["nrows", "ncols", "data"];
+        struct MatVisitor<E: Entity>(PhantomData<E>);
+        impl<'a, E: Entity + Deserialize<'a>> Visitor<'a> for MatVisitor<E> {
+            type Value = Mat<E>;
+
+            fn expecting(&self, formatter: &mut alloc::fmt::Formatter) -> alloc::fmt::Result {
+                formatter.write_str("a faer matrix")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'a>,
+            {
+                enum MatrixOrVec<E: Entity> {
+                    Matrix(Mat<E>),
+                    Vec(Vec<E>),
+                }
+                impl<E: Entity> MatrixOrVec<E> {
+                    fn into_mat(self, nrows: usize, ncols: usize) -> Mat<E> {
+                        match self {
+                            MatrixOrVec::Matrix(m) => m,
+                            MatrixOrVec::Vec(v) => {
+                                Mat::from_fn(nrows, ncols, |i, j| v[i * ncols + j])
+                            }
+                        }
+                    }
+                }
+                struct MatrixOrVecDeserializer<'a, E: Entity + Deserialize<'a>> {
+                    marker: PhantomData<&'a E>,
+                    nrows: Option<usize>,
+                    ncols: Option<usize>,
+                }
+                impl<'a, E: Entity + Deserialize<'a>> MatrixOrVecDeserializer<'a, E> {
+                    fn new(nrows: Option<usize>, ncols: Option<usize>) -> Self {
+                        Self {
+                            marker: PhantomData,
+                            nrows,
+                            ncols,
+                        }
+                    }
+                }
+                impl<'a, E: Entity> DeserializeSeed<'a> for MatrixOrVecDeserializer<'a, E>
+                where
+                    E: Deserialize<'a>,
+                {
+                    type Value = MatrixOrVec<E>;
+
+                    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+                    where
+                        D: serde::Deserializer<'a>,
+                    {
+                        deserializer.deserialize_seq(self)
+                    }
+                }
+                impl<'a, E: Entity> Visitor<'a> for MatrixOrVecDeserializer<'a, E>
+                where
+                    E: Deserialize<'a>,
+                {
+                    type Value = MatrixOrVec<E>;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut alloc::fmt::Formatter,
+                    ) -> alloc::fmt::Result {
+                        formatter.write_str("a sequence")
+                    }
+
+                    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+                    where
+                        A: SeqAccess<'a>,
+                    {
+                        match (self.ncols, self.nrows) {
+                            (Some(ncols), Some(nrows)) => {
+                                let ncols = ncols;
+                                let nrows = nrows;
+                                let mut data = Mat::<E>::with_capacity(nrows, ncols);
+                                unsafe {
+                                    data.set_dims(nrows, ncols);
+                                }
+                                let mut i = 0;
+                                while let Some(el) = seq.next_element::<E>()? {
+                                    data.write(i / ncols, i % ncols, el);
+                                    i += 1;
+                                }
+                                if i < nrows * ncols {
+                                    return Err(serde::de::Error::invalid_length(
+                                        i,
+                                        &format!("{} elements", nrows * ncols).as_str(),
+                                    ));
+                                }
+                                Ok(MatrixOrVec::Matrix(data))
+                            }
+                            _ => {
+                                let mut data = Vec::new();
+                                while let Some(el) = seq.next_element::<E>()? {
+                                    data.push(el);
+                                }
+                                Ok(MatrixOrVec::Vec(data))
+                            }
+                        }
+                    }
+                }
+                let mut nrows = None;
+                let mut ncols = None;
+                let mut data: Option<MatrixOrVec<E>> = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Nrows => {
+                            if nrows.is_some() {
+                                return Err(serde::de::Error::duplicate_field("nrows"));
+                            }
+                            let value = map.next_value()?;
+                            nrows = Some(value);
+                        }
+                        Field::Ncols => {
+                            if ncols.is_some() {
+                                return Err(serde::de::Error::duplicate_field("ncols"));
+                            }
+                            let value = map.next_value()?;
+                            ncols = Some(value);
+                        }
+                        Field::Data => {
+                            if data.is_some() {
+                                return Err(serde::de::Error::duplicate_field("data"));
+                            }
+                            data = Some(map.next_value_seed(MatrixOrVecDeserializer::<E>::new(
+                                nrows.clone(),
+                                ncols.clone(),
+                            ))?);
+                        }
+                    }
+                }
+                let nrows = nrows.ok_or_else(|| serde::de::Error::missing_field("nrows"))?;
+                let ncols = ncols.ok_or_else(|| serde::de::Error::missing_field("ncols"))?;
+                let data = data
+                    .ok_or_else(|| serde::de::Error::missing_field("data"))?
+                    .into_mat(nrows, ncols);
+                Ok(data)
+            }
+        }
+        d.deserialize_struct("Mat", FIELDS, MatVisitor(PhantomData))
     }
 }
 
@@ -73,25 +211,18 @@ mod tests {
     use super::*;
     use serde_test::{assert_de_tokens_error, assert_tokens, Token};
     #[test]
-    fn mat_to_serde_mat_and_back_again() {
-        let mat = Mat::from_fn(3, 4, |i, j| (i + (j * 10)) as f64);
-        let serde_mat: SerdeMat<f64> = (&mat).into();
-        println!("{:?}", serde_mat);
-        let mat_again: Mat<f64> = serde_mat.into();
-        assert_eq!(mat_again, mat);
-    }
-
-    #[test]
-    fn mat_serialization() {
-        let mat = Mat::from_fn(3, 4, |i, j| (i + (j * 10)) as f64);
+    fn matrix_serialization_normal() {
+        let value = Mat::from_fn(3, 4, |i, j| (i + (j * 10)) as f64);
         assert_tokens(
-            &mat,
+            &value,
             &[
                 Token::Struct {
-                    len: 2,
-                    name: "SerdeMat",
+                    name: "Mat",
+                    len: 3,
                 },
-                Token::Str("col_length"),
+                Token::Str("nrows"),
+                Token::U64(3),
+                Token::Str("ncols"),
                 Token::U64(4),
                 Token::Str("data"),
                 Token::Seq { len: Some(12) },
@@ -114,25 +245,121 @@ mod tests {
     }
 
     #[test]
-    fn deserialization_can_fail() {
-        assert_de_tokens_error::<Mat<f64>>(
+    fn matrix_serialization_wide() {
+        let value = Mat::from_fn(12, 1, |i, j| (i + (j * 10)) as f64);
+        assert_tokens(
+            &value,
             &[
                 Token::Struct {
-                    len: 2,
-                    name: "SerdeMat",
+                    name: "Mat",
+                    len: 3,
                 },
-                Token::Str("col_length"),
-                Token::U64(3),
+                Token::Str("nrows"),
+                Token::U64(12),
+                Token::Str("ncols"),
+                Token::U64(1),
                 Token::Str("data"),
                 Token::Seq { len: Some(12) },
                 Token::F64(0.0),
                 Token::F64(1.0),
                 Token::F64(2.0),
                 Token::F64(3.0),
+                Token::F64(4.0),
+                Token::F64(5.0),
+                Token::F64(6.0),
+                Token::F64(7.0),
+                Token::F64(8.0),
+                Token::F64(9.0),
+                Token::F64(10.0),
+                Token::F64(11.0),
                 Token::SeqEnd,
                 Token::StructEnd,
             ],
-            "serialized matrix is now valid as col_length isnt a divisor of the length of the data",
+        )
+    }
+
+    #[test]
+    fn matrix_serialization_tall() {
+        let value = Mat::from_fn(1, 12, |i, j| (i + (j * 10)) as f64);
+        assert_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "Mat",
+                    len: 3,
+                },
+                Token::Str("nrows"),
+                Token::U64(1),
+                Token::Str("ncols"),
+                Token::U64(12),
+                Token::Str("data"),
+                Token::Seq { len: Some(12) },
+                Token::F64(0.0),
+                Token::F64(10.0),
+                Token::F64(20.0),
+                Token::F64(30.0),
+                Token::F64(40.0),
+                Token::F64(50.0),
+                Token::F64(60.0),
+                Token::F64(70.0),
+                Token::F64(80.0),
+                Token::F64(90.0),
+                Token::F64(100.0),
+                Token::F64(110.0),
+                Token::SeqEnd,
+                Token::StructEnd,
+            ],
+        )
+    }
+
+    #[test]
+    fn matrix_serialization_zero() {
+        let value = Mat::from_fn(0, 0, |i, j| (i + (j * 10)) as f64);
+        assert_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "Mat",
+                    len: 3,
+                },
+                Token::Str("nrows"),
+                Token::U64(0),
+                Token::Str("ncols"),
+                Token::U64(0),
+                Token::Str("data"),
+                Token::Seq { len: Some(0) },
+                Token::SeqEnd,
+                Token::StructEnd,
+            ],
+        )
+    }
+
+    #[test]
+    fn matrix_serialization_errors_with_too_smaller_size() {
+        assert_de_tokens_error::<Mat<f64>>(
+            &[
+                Token::Struct {
+                    name: "Mat",
+                    len: 3,
+                },
+                Token::Str("nrows"),
+                Token::U64(3),
+                Token::Str("ncols"),
+                Token::U64(4),
+                Token::Str("data"),
+                Token::Seq { len: Some(12) },
+                Token::F64(0.0),
+                Token::F64(10.0),
+                Token::F64(20.0),
+                Token::F64(30.0),
+                Token::F64(1.0),
+                Token::F64(11.0),
+                Token::F64(21.0),
+                Token::F64(31.0),
+                Token::F64(2.0),
+                Token::SeqEnd,
+            ],
+            "invalid length 9, expected 12 elements",
         )
     }
 }


### PR DESCRIPTION
Added a feature to support serde serialization on the `Mat` type.

This is implemented by having a simple struct we can `derive(Serialize, Deserialize)` on, which represents the matrix in its serialized form, which is as a long vector along with the col length.

I wasn't sure if i should implement other matrix types than `Matrix<DenseOwn>` (which `Mat` ofc is an alias for), but im hoping i will get some feedback on that particular question