### PR TITLE
fix documentation for subrows() and subrows_mut()

### DIFF
--- a/src/col/colmut.rs
+++ b/src/col/colmut.rs
@@ -382,8 +382,8 @@ impl<'a, E: Entity> ColMut<'a, E> {
     /// Returns a view over the subvector starting at row `row_start`, and with number of rows
     /// `nrows`.
     ///
-    /// # Safety
-    /// The behavior is undefined if any of the following conditions are violated:
+    /// # Panics
+    /// The function panics if any of the following conditions are violated:
     /// * `row_start <= self.nrows()`.
     /// * `nrows <= self.nrows() - row_start`.
     #[track_caller]

--- a/src/col/colref.rs
+++ b/src/col/colref.rs
@@ -381,8 +381,8 @@ impl<'a, E: Entity> ColRef<'a, E> {
     /// Returns a view over the subvector starting at row `row_start`, and with number of rows
     /// `nrows`.
     ///
-    /// # Safety
-    /// The behavior is undefined if any of the following conditions are violated:
+    /// # Panics
+    /// The function panics if any of the following conditions are violated:
     /// * `row_start <= self.nrows()`.
     /// * `nrows <= self.nrows() - row_start`.
     #[track_caller]


### PR DESCRIPTION
Looks like a copy-and-paste error in the documentation. Current documentation says these (not-unsafe) functions exhibit undefined behavior. However the code appears to panic.