### PR TITLE
no-std requires dyn-stack without default-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ dbgf = "0.1.2"
 paste = "1.0.14"
 reborrow = "0.5.5"
 
-dyn-stack = "0.10.0"
+dyn-stack = { version = "0.10.0", default-features = false }
 equator = "0.1.10"
 faer-entity = { version ="0.18.0", default-features = false, path = "./faer-entity" }
 


### PR DESCRIPTION
Trying to include faer in a no-std project produced errors. The reason was that faer includes dyn-stack, which in turn includes the standard library by default. 