### PR TITLE
Change `div_ceil` to `msrv_div_ceil`

### DIFF
--- a/src/linop/lsmr.rs
+++ b/src/linop/lsmr.rs
@@ -819,7 +819,7 @@ mod tests {
             );
             assert!(result.is_ok());
             let result = result.unwrap();
-            assert!(result.iter_count <= (4 * n).div_ceil(Ord::min(k, n)));
+            assert!(result.iter_count <= (4 * n).msrv_div_ceil(Ord::min(k, n)));
         }
     }
 
@@ -859,7 +859,7 @@ mod tests {
             );
             assert!(result.is_ok());
             let result = result.unwrap();
-            assert!(result.iter_count <= (4 * n).div_ceil(Ord::min(k, n)));
+            assert!(result.iter_count <= (4 * n).msrv_div_ceil(Ord::min(k, n)));
         }
     }
 }


### PR DESCRIPTION
# Change
It has been modified to use `msrv_div_ceil`, which is implemented in the `utils` of this repository, instead of the `div_ceil`.

# Reason
[The `div_ceil` is unstable,](https://github.com/rust-lang/rust/issues/88581) which causes build errors such as the one in the image sent. To avoid this error.
![divceil](https://github.com/sarah-ek/faer-rs/assets/42142120/cf6ccc88-ff3a-4c67-8055-e7233a1632f2)

# Supplement
I have also confirmed that all tests of `cargo test` are completed without any problems.