### PR TITLE
Feature/issue 125 more matrix constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [Unreleased]
+- Add `full` and `zeros` constructors to owned Col, Row, and Matrix ([issue-125](https://github.com/sarah-ek/faer-rs/issues/125)).
+
 # 0.18
 - Refactored the project so that `faer` contains all the core and decomposition implementations. `faer-{core,cholesky,lu,qr,svd,evd,sparse}` are now deprecated and will no longer be updated.
 - Improved the multithreaded performance of the Eigenvalue decomposition for large matrices.

--- a/src/col/colown.rs
+++ b/src/col/colown.rs
@@ -85,6 +85,30 @@ impl<E: Entity> Col<E> {
         Self::from_fn(nrows, |_| unsafe { core::mem::zeroed() })
     }
 
+    /// Returns a new matrix with number of rows `nrows`, filled with ones.
+    ///
+    /// # Panics
+    /// The function panics if the total capacity in bytes exceeds `isize::MAX`.
+    #[inline]
+    pub fn ones(nrows: usize) -> Self
+    where
+        E: ComplexField,
+    {
+        Self::from_fn(nrows, |_| E::faer_one())
+    }
+
+    /// Returns a new matrix with number of rows `nrows`, filled with a constant value.
+    ///
+    /// # Panics
+    /// The function panics if the total capacity in bytes exceeds `isize::MAX`.
+    #[inline]
+    pub fn full(nrows: usize, constant: E) -> Self
+    where
+        E: ComplexField,
+    {
+        Self::from_fn(nrows, |_| constant)
+    }
+
     /// Returns the number of rows of the column.
     #[inline(always)]
     pub fn nrows(&self) -> usize {

--- a/src/mat/matown.rs
+++ b/src/mat/matown.rs
@@ -110,6 +110,30 @@ impl<E: Entity> Mat<E> {
         Self::from_fn(nrows, ncols, |_, _| unsafe { core::mem::zeroed() })
     }
 
+    /// Returns a new matrix with dimensions `(nrows, ncols)`, filled with ones.
+    ///
+    /// # Panics
+    /// The function panics if the total capacity in bytes exceeds `isize::MAX`.
+    #[inline]
+    pub fn ones(nrows: usize, ncols: usize) -> Self
+    where
+        E: ComplexField,
+    {
+        Self::from_fn(nrows, ncols, |_, _| E::faer_one())
+    }
+
+    /// Returns a new matrix with dimensions `(nrows, ncols)`, filled with a constant value.
+    ///
+    /// # Panics
+    /// The function panics if the total capacity in bytes exceeds `isize::MAX`.
+    #[inline]
+    pub fn full(nrows: usize, ncols: usize, constant: E) -> Self
+    where
+        E: ComplexField,
+    {
+        Self::from_fn(nrows, ncols, |_, _| constant)
+    }
+
     /// Returns a new matrix with dimensions `(nrows, ncols)`, filled with zeros, except the main
     /// diagonal which is filled with ones.
     ///

--- a/src/row/rowown.rs
+++ b/src/row/rowown.rs
@@ -84,6 +84,30 @@ impl<E: Entity> Row<E> {
         Self::from_fn(ncols, |_| unsafe { core::mem::zeroed() })
     }
 
+    /// Returns a new matrix with number of columns `ncols`, filled with ones.
+    ///
+    /// # Panics
+    /// The function panics if the total capacity in bytes exceeds `isize::MAX`.
+    #[inline]
+    pub fn ones(ncols: usize) -> Self
+    where
+        E: ComplexField,
+    {
+        Self::from_fn(ncols, |_| E::faer_one())
+    }
+
+    /// Returns a new matrix with number of columns `ncols`, filled with a constant value.
+    ///
+    /// # Panics
+    /// The function panics if the total capacity in bytes exceeds `isize::MAX`.
+    #[inline]
+    pub fn full(ncols: usize, constant: E) -> Self
+    where
+        E: ComplexField,
+    {
+        Self::from_fn(ncols, |_| constant)
+    }
+
     /// Returns the number of rows of the row. This is always equal to `1`.
     #[inline(always)]
     pub fn nrows(&self) -> usize {


### PR DESCRIPTION
Added the `full` and `ones` constructors for owned Row, Col, and Matrix.