### PR TITLE
Correct typos in documentation

### DIFF
--- a/faer-entity/src/lib.rs
+++ b/faer-entity/src/lib.rs
@@ -2646,7 +2646,7 @@ impl<I: Iterator> Iterator for ComplexConjIter<I> {
 /// Utilities for split complex number types whose real and imaginary parts are stored separately.
 pub mod complex_split {
 
-    /// This structure contains the real and imaginary parts of an implicity conjugated value.
+    /// This structure contains the real and imaginary parts of an implicitly conjugated value.
     #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     #[repr(C)]
     pub struct ComplexConj<T> {

--- a/src/col/colmut.rs
+++ b/src/col/colmut.rs
@@ -604,7 +604,7 @@ impl<'a, E: Entity> ColMut<'a, E> {
     }
 
     /// Given a matrix with a single column, returns an object that interprets
-    /// the column as a diagonal matrix, whoes diagonal elements are values in the column.
+    /// the column as a diagonal matrix, whose diagonal elements are values in the column.
     #[track_caller]
     #[inline(always)]
     pub fn column_vector_as_diagonal(self) -> DiagRef<'a, E> {
@@ -612,7 +612,7 @@ impl<'a, E: Entity> ColMut<'a, E> {
     }
 
     /// Given a matrix with a single column, returns an object that interprets
-    /// the column as a diagonal matrix, whoes diagonal elements are values in the column.
+    /// the column as a diagonal matrix, whose diagonal elements are values in the column.
     #[track_caller]
     #[inline(always)]
     pub fn column_vector_as_diagonal_mut(self) -> DiagMut<'a, E> {

--- a/src/col/colown.rs
+++ b/src/col/colown.rs
@@ -777,7 +777,7 @@ impl<E: Entity> Col<E> {
     }
 
     /// Given a matrix with a single column, returns an object that interprets
-    /// the column as a diagonal matrix, whoes diagonal elements are values in the column.
+    /// the column as a diagonal matrix, whose diagonal elements are values in the column.
     #[track_caller]
     #[inline(always)]
     pub fn column_vector_as_diagonal(&self) -> DiagRef<'_, E> {
@@ -785,7 +785,7 @@ impl<E: Entity> Col<E> {
     }
 
     /// Given a matrix with a single column, returns an object that interprets
-    /// the column as a diagonal matrix, whoes diagonal elements are values in the column.
+    /// the column as a diagonal matrix, whose diagonal elements are values in the column.
     #[track_caller]
     #[inline(always)]
     pub fn column_vector_as_diagonal_mut(&mut self) -> DiagMut<'_, E> {
@@ -793,7 +793,7 @@ impl<E: Entity> Col<E> {
     }
 
     /// Given a matrix with a single column, returns an object that interprets
-    /// the column as a diagonal matrix, whoes diagonal elements are values in the column.
+    /// the column as a diagonal matrix, whose diagonal elements are values in the column.
     #[track_caller]
     #[inline(always)]
     pub fn column_vector_into_diagonal(self) -> Diag<E> {

--- a/src/col/colref.rs
+++ b/src/col/colref.rs
@@ -398,7 +398,7 @@ impl<'a, E: Entity> ColRef<'a, E> {
     }
 
     /// Given a matrix with a single column, returns an object that interprets
-    /// the column as a diagonal matrix, whoes diagonal elements are values in the column.
+    /// the column as a diagonal matrix, whose diagonal elements are values in the column.
     #[track_caller]
     #[inline(always)]
     pub fn column_vector_as_diagonal(self) -> DiagRef<'a, E> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,7 +413,7 @@ macro_rules! __perf_warn {
     }};
 }
 
-/// Convenience function to concatonate a nested list of matrices into a single
+/// Convenience function to concatenate a nested list of matrices into a single
 /// big ['Mat']. Concatonation pattern follows the numpy.block convention that
 /// each sub-list must have an equal number of columns (net) but the boundaries
 /// do not need to align. In other words, this sort of thing:
@@ -830,7 +830,7 @@ pub enum Parallelism {
     /// The code is executed sequentially on the same thread that calls a function
     /// and passes this argument.
     None,
-    /// Rayon parallelism. Only avaialble with the `rayon` feature.
+    /// Rayon parallelism. Only available with the `rayon` feature.
     ///
     /// The code is possibly executed in parallel on the current thread, as well as the currently
     /// active rayon thread pool.

--- a/src/linalg/cholesky/ldlt_diagonal/mod.rs
+++ b/src/linalg/cholesky/ldlt_diagonal/mod.rs
@@ -9,7 +9,7 @@
 
 /// Computing the decomposition.
 pub mod compute;
-/// Solving a linear system usin the decomposition.
+/// Solving a linear system using the decomposition.
 pub mod solve;
 /// Updating the decomposition.
 pub mod update;

--- a/src/linalg/cholesky/llt/mod.rs
+++ b/src/linalg/cholesky/llt/mod.rs
@@ -8,7 +8,7 @@ pub mod compute;
 pub mod inverse;
 /// Reconstructing the original matrix from the decomposition.
 pub mod reconstruct;
-/// Solving a linear system usin the decomposition.
+/// Solving a linear system using the decomposition.
 pub mod solve;
 /// Updating the decomposition.
 pub mod update;

--- a/src/linalg/evd/hessenberg_cplx_evd.rs
+++ b/src/linalg/evd/hessenberg_cplx_evd.rs
@@ -900,7 +900,7 @@ fn aggressive_early_deflation<E: ComplexField>(
     }
 
     if ns == jw {
-        // Agressive early deflation didn't deflate any eigenvalues
+        // Aggressive early deflation didn't deflate any eigenvalues
         // We don't need to apply the update to the rest of the matrix
         nd = jw - ns;
         ns -= infqr;
@@ -959,7 +959,7 @@ fn aggressive_early_deflation<E: ComplexField>(
         i += 1;
     }
 
-    // Reduce A back to Hessenberg form (if neccesary)
+    // Reduce A back to Hessenberg form (if necessary)
     if s_spike != E::faer_zero() {
         // Reflect spike back
         {
@@ -1396,7 +1396,7 @@ pub fn multishift_qr<E: ComplexField>(
         }
 
         //
-        // Agressive early deflation
+        // Aggressive early deflation
         //
         let nh = istop - istart;
         let nwupbd = Ord::min(nh, nw_max);
@@ -2021,7 +2021,7 @@ fn multishift_qr_sweep<E: ComplexField>(
     }
 
     //
-    // The following code block moves the bulges down untill they are low enough
+    // The following code block moves the bulges down until they are low enough
     // to be removed
     //
     while i_pos_block + n_block_desired < ihi {

--- a/src/linalg/evd/hessenberg_real_evd.rs
+++ b/src/linalg/evd/hessenberg_real_evd.rs
@@ -1602,7 +1602,7 @@ fn aggressive_early_deflation<E: RealField>(
     }
 
     if ns == jw {
-        // Agressive early deflation didn't deflate any eigenvalues
+        // Aggressive early deflation didn't deflate any eigenvalues
         // We don't need to apply the update to the rest of the matrix
         nd = jw - ns;
         ns -= infqr;
@@ -1714,7 +1714,7 @@ fn aggressive_early_deflation<E: RealField>(
         i += n1;
     }
 
-    // Reduce A back to Hessenberg form (if neccesary)
+    // Reduce A back to Hessenberg form (if necessary)
     if s_spike != E::faer_zero() {
         // Reflect spike back
         {
@@ -2356,7 +2356,7 @@ fn multishift_qr_sweep<E: RealField>(
     }
 
     //
-    // The following code block moves the bulges down untill they are low enough
+    // The following code block moves the bulges down until they are low enough
     // to be removed
     //
     while i_pos_block + n_block_desired < ihi {
@@ -3178,7 +3178,7 @@ pub fn multishift_qr<E: RealField>(
         }
 
         //
-        // Agressive early deflation
+        // Aggressive early deflation
         //
         let nh = istop - istart;
         let nwupbd = Ord::min(nh, nw_max);

--- a/src/linalg/householder.rs
+++ b/src/linalg/householder.rs
@@ -1,6 +1,6 @@
 //! Block Householder transformations.
 //!
-//! A Householder reflection is linear transformation that describes a relfection about a
+//! A Householder reflection is linear transformation that describes a reflection about a
 //! hyperplane that crosses the origin of the space.
 //!
 //! Let $v$ be a unit vector that is orthogonal to the hyperplane. Then the corresponding

--- a/src/linalg/lu/full_pivoting/mod.rs
+++ b/src/linalg/lu/full_pivoting/mod.rs
@@ -12,5 +12,5 @@ pub mod compute;
 pub mod inverse;
 /// Reconstructing the inverse of the original matrix from the decomposition.
 pub mod reconstruct;
-/// Solving a linear system usin the decomposition.
+/// Solving a linear system using the decomposition.
 pub mod solve;

--- a/src/linalg/lu/partial_pivoting/mod.rs
+++ b/src/linalg/lu/partial_pivoting/mod.rs
@@ -9,5 +9,5 @@ pub mod compute;
 pub mod inverse;
 /// Reconstructing the original matrix from the decomposition.
 pub mod reconstruct;
-/// Solving a linear system usin the decomposition.
+/// Solving a linear system using the decomposition.
 pub mod solve;

--- a/src/linalg/mod.rs
+++ b/src/linalg/mod.rs
@@ -26,7 +26,7 @@
 //! required memory. The simplest way to do so is through [`dyn_stack::GlobalMemBuffer::new`].
 //!
 //! # Entity trait
-//! Matrices are built on top of the [`Entity`] trait, which describes the prefered memory
+//! Matrices are built on top of the [`Entity`] trait, which describes the preferred memory
 //! storage layout for a given type `E`. An entity can be decomposed into a group of units: for
 //! a natively supported type ([`f32`], [`f64`], [`c32`](crate::complex_native::c32),
 //! [`c64`](crate::complex_native::c64)), the unit is simply the type itself, and a group
@@ -45,8 +45,8 @@
 //! respectively to a view over the real and the imaginary components.
 //!
 //! While the design of the entity trait is unconventional, it helps us achieve much higher
-//! performance when targetting non native types, due to the design matching the typical
-//! preffered CPU layout for SIMD operations. And for native types, since [`Group<T>` is just
+//! performance when targeting non native types, due to the design matching the typical
+//! preferred CPU layout for SIMD operations. And for native types, since [`Group<T>` is just
 //! `T`](Entity#impl-Entity-for-f64), the entity layer is a no-op, and the matrix layout is
 //! compatible with the classic contiguous layout that's commonly used by other libraries.
 

--- a/src/linalg/qr/col_pivoting/compute.rs
+++ b/src/linalg/qr/col_pivoting/compute.rs
@@ -701,7 +701,7 @@ pub struct ColPivQrInfo {
 /// an implicit unit diagonal, and its upper triangular Householder factors are stored in
 /// `householder_factor`, blockwise in chunks of `blocksize×blocksize`.
 ///
-/// The block size is chosed as the number of rows of `householder_factor`.
+/// The block size is chosen as the number of rows of `householder_factor`.
 ///
 /// After the function returns, `col_perm` contains the order of the columns after pivoting, i.e.
 /// the result is the same as computing the non-pivoted QR decomposition of the matrix `matrix[:,

--- a/src/linalg/qr/col_pivoting/mod.rs
+++ b/src/linalg/qr/col_pivoting/mod.rs
@@ -9,5 +9,5 @@ pub mod compute;
 pub mod inverse;
 /// Reconstructing the original matrix from the decomposition.
 pub mod reconstruct;
-/// Solving a linear system usin the decomposition.
+/// Solving a linear system using the decomposition.
 pub mod solve;

--- a/src/linalg/qr/no_pivoting/compute.rs
+++ b/src/linalg/qr/no_pivoting/compute.rs
@@ -303,7 +303,7 @@ fn qr_in_place_blocked<E: ComplexField>(
 /// an implicit unit diagonal, and its upper triangular Householder factors are stored in
 /// `householder_factor`, blockwise in chunks of `blocksize×blocksize`.
 ///
-/// The block size is chosed as the number of rows of `householder_factor`.
+/// The block size is chosen as the number of rows of `householder_factor`.
 ///
 /// # Panics
 ///

--- a/src/linalg/qr/no_pivoting/mod.rs
+++ b/src/linalg/qr/no_pivoting/mod.rs
@@ -9,5 +9,5 @@ pub mod compute;
 pub mod inverse;
 /// Reconstructing the original matrix from the decomposition.
 pub mod reconstruct;
-/// Solving a linear system usin the decomposition.
+/// Solving a linear system using the decomposition.
 pub mod solve;

--- a/src/linalg/solvers.rs
+++ b/src/linalg/solvers.rs
@@ -508,7 +508,7 @@ impl<E: ComplexField> PartialPivLu<E> {
         unsafe { PermRef::new_unchecked(&self.row_perm, &self.row_perm_inv) }
     }
 
-    /// Returns the number of transpositions that consitute the permutation.
+    /// Returns the number of transpositions that constitute the permutation.
     pub fn transposition_count(&self) -> usize {
         self.n_transpositions
     }
@@ -697,7 +697,7 @@ impl<E: ComplexField> FullPivLu<E> {
         unsafe { PermRef::new_unchecked(&self.col_perm, &self.col_perm_inv) }
     }
 
-    /// Returns the number of transpositions that consitute the two permutations.
+    /// Returns the number of transpositions that constitute the two permutations.
     pub fn transposition_count(&self) -> usize {
         self.n_transpositions
     }

--- a/src/mat/matmut.rs
+++ b/src/mat/matmut.rs
@@ -1437,7 +1437,7 @@ impl<'a, E: Entity> MatMut<'a, E> {
     }
 
     /// Given a matrix with a single column, returns an object that interprets
-    /// the column as a diagonal matrix, whoes diagonal elements are values in the column.
+    /// the column as a diagonal matrix, whose diagonal elements are values in the column.
     #[track_caller]
     #[inline(always)]
     pub fn column_vector_as_diagonal(self) -> DiagRef<'a, E> {
@@ -1445,7 +1445,7 @@ impl<'a, E: Entity> MatMut<'a, E> {
     }
 
     /// Given a matrix with a single column, returns an object that interprets
-    /// the column as a diagonal matrix, whoes diagonal elements are values in the column.
+    /// the column as a diagonal matrix, whose diagonal elements are values in the column.
     #[track_caller]
     #[inline(always)]
     pub fn column_vector_as_diagonal_mut(self) -> DiagMut<'a, E> {

--- a/src/mat/matown.rs
+++ b/src/mat/matown.rs
@@ -1605,7 +1605,7 @@ impl<E: Entity> Mat<E> {
     }
 
     /// Given a matrix with a single column, returns an object that interprets
-    /// the column as a diagonal matrix, whoes diagonal elements are values in the column.
+    /// the column as a diagonal matrix, whose diagonal elements are values in the column.
     #[track_caller]
     #[inline(always)]
     pub fn column_vector_as_diagonal(&self) -> DiagRef<'_, E> {
@@ -1613,7 +1613,7 @@ impl<E: Entity> Mat<E> {
     }
 
     /// Given a matrix with a single column, returns an object that interprets
-    /// the column as a diagonal matrix, whoes diagonal elements are values in the column.
+    /// the column as a diagonal matrix, whose diagonal elements are values in the column.
     #[track_caller]
     #[inline(always)]
     pub fn column_vector_as_diagonal_mut(&mut self) -> DiagMut<'_, E> {

--- a/src/mat/matref.rs
+++ b/src/mat/matref.rs
@@ -834,7 +834,7 @@ impl<'a, E: Entity> MatRef<'a, E> {
     }
 
     /// Given a matrix with a single column, returns an object that interprets
-    /// the column as a diagonal matrix, whoes diagonal elements are values in the column.
+    /// the column as a diagonal matrix, whose diagonal elements are values in the column.
     #[track_caller]
     #[inline(always)]
     pub fn column_vector_as_diagonal(self) -> DiagRef<'a, E> {

--- a/src/row/rowmut.rs
+++ b/src/row/rowmut.rs
@@ -512,14 +512,14 @@ impl<'a, E: Entity> RowMut<'a, E> {
         unsafe { (canon.const_cast(), conj) }
     }
 
-    /// Returns a view over the `self`, with the columnss in reversed order.
+    /// Returns a view over the `self`, with the columns in reversed order.
     #[inline(always)]
     #[must_use]
     pub fn reverse_cols(self) -> RowRef<'a, E> {
         self.into_const().reverse_cols()
     }
 
-    /// Returns a view over the `self`, with the columnss in reversed order.
+    /// Returns a view over the `self`, with the columns in reversed order.
     #[inline(always)]
     #[must_use]
     pub fn reverse_cols_mut(self) -> Self {

--- a/src/row/rowown.rs
+++ b/src/row/rowown.rs
@@ -46,7 +46,7 @@ impl<E: Entity> Row<E> {
     }
 
     /// Returns a new column vector with 0 columns, with enough capacity to hold a maximum of
-    /// `col_capacity` columnss columns without reallocating. If `col_capacity` is `0`,
+    /// `col_capacity` columns without reallocating. If `col_capacity` is `0`,
     /// the function will not allocate.
     ///
     /// # Panics
@@ -778,14 +778,14 @@ impl<E: Entity> Row<E> {
         self.as_mut().canonicalize_mut()
     }
 
-    /// Returns a view over the `self`, with the columnss in reversed order.
+    /// Returns a view over the `self`, with the columns in reversed order.
     #[inline(always)]
     #[must_use]
     pub fn reverse_cols(&self) -> RowRef<'_, E> {
         self.as_ref().reverse_cols()
     }
 
-    /// Returns a view over the `self`, with the columnss in reversed order.
+    /// Returns a view over the `self`, with the columns in reversed order.
     #[inline(always)]
     #[must_use]
     pub fn reverse_cols_mut(&mut self) -> RowMut<'_, E> {

--- a/src/row/rowref.rs
+++ b/src/row/rowref.rs
@@ -336,7 +336,7 @@ impl<'a, E: Entity> RowRef<'a, E> {
         )
     }
 
-    /// Returns a view over the `self`, with the columnss in reversed order.
+    /// Returns a view over the `self`, with the columns in reversed order.
     #[inline(always)]
     #[must_use]
     pub fn reverse_cols(self) -> Self {


### PR DESCRIPTION
Minor typos only, found using [typos](https://crates.io/crates/typos)