### PR TITLE
Adds `derive(Clone)` to the owned sparse matrix formats 

### DIFF
--- a/src/sparse/csc/matown.rs
+++ b/src/sparse/csc/matown.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::assert;
 
+#[derive(Clone)]
 /// Sparse matrix in column-major format, either compressed or uncompressed.
 pub struct SparseColMat<I: Index, E: Entity> {
     pub(crate) symbolic: SymbolicSparseColMat<I>,

--- a/src/sparse/csr/matown.rs
+++ b/src/sparse/csr/matown.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::assert;
 
+#[derive(Clone)]
 /// Sparse matrix in column-major format, either compressed or uncompressed.
 pub struct SparseRowMat<I: Index, E: Entity> {
     pub(crate) symbolic: SymbolicSparseRowMat<I>,


### PR DESCRIPTION
Nothing complicated here, just adding a few `derive(Clone)` we needed for the CVXPY rust backend.