### PR TITLE
Fix mismatched types in `panic_handler` in `no_std`

### DIFF
--- a/faer-no-std-test/src/main.rs
+++ b/faer-no-std-test/src/main.rs
@@ -41,9 +41,7 @@ unsafe impl GlobalAlloc for Allocator {
 
 #[panic_handler]
 fn panic(panic_info: &core::panic::PanicInfo) -> ! {
-    if let Some(message) = panic_info.message() {
-        libc_print::libc_eprintln!("{message}");
-    }
+    libc_print::libc_eprintln!("{}", panic_info);
 
     unsafe { libc::exit(1) };
 }


### PR DESCRIPTION
# Change
Fix mismatched types in `panic_handler` in `no_std`.
![error1](https://github.com/sarah-ek/faer-rs/assets/42142120/31b0aa79-891b-4a66-bd2f-90af58d0f638)

# Reason
[To resolve errors in GHA checks](https://github.com/sarah-ek/faer-rs/actions/runs/9633844005/job/26568721484) and properly pass CI.

# TEST 
The GHA checks of this PR were properly passed.
![passed](https://github.com/sarah-ek/faer-rs/assets/42142120/093ffa9b-6ca8-4b2b-a4d6-ef55eb44a206)


# Supplement
https://ferrous-systems.com/blog/probe-run/