### PR TITLE
feat: support visit_seq for Deserialize

### DIFF
--- a/src/col/colown.rs
+++ b/src/col/colown.rs
@@ -1069,7 +1069,8 @@ impl<E: Entity> Clone for Col<E> {
                 E::faer_from_units(E::faer_deref(this.get_unchecked(i)))
             })
         }
-    }fn clone_from(&mut self,other:&Self){
+    }
+    fn clone_from(&mut self, other: &Self) {
         self.resize_with(0, |_| E::zeroed());
         self.resize_with(
             other.nrows(),

--- a/src/mat/matown.rs
+++ b/src/mat/matown.rs
@@ -1044,7 +1044,7 @@ impl<E: Entity> Mat<E> {
             this: &mut Mat<E>,
             other: MatRef<'_, ViewE>,
         ) {
-            let (rows, cols)=other.shape();
+            let (rows, cols) = other.shape();
             this.resize_with(0, 0, |_, _| E::zeroed());
             this.resize_with(
                 rows,
@@ -2070,9 +2070,9 @@ impl<E: Entity> Clone for Mat<E> {
             })
         }
     }
-    
+
     fn clone_from(&mut self, other: &Self) {
-        let (rows, cols)=other.shape();
+        let (rows, cols) = other.shape();
         self.resize_with(0, 0, |_, _| E::zeroed());
         self.resize_with(
             rows,

--- a/src/row/rowown.rs
+++ b/src/row/rowown.rs
@@ -1030,8 +1030,8 @@ impl<E: Entity> Clone for Row<E> {
             })
         }
     }
-    
-    fn clone_from(&mut self, other: &Self){
+
+    fn clone_from(&mut self, other: &Self) {
         self.resize_with(0, |_| E::zeroed());
         self.resize_with(
             other.nrows(),

--- a/src/sparse/linalg/solvers.rs
+++ b/src/sparse/linalg/solvers.rs
@@ -27,11 +27,14 @@ pub trait SpSolverLstsqCore<E: Entity>: SpSolverCore<E> {
 pub trait SpSolver<E: ComplexField>: SpSolverCore<E> {
     /// Solves the equation `self * X = rhs` when self is square, and stores the result in `rhs`.
     fn solve_in_place(&self, rhs: impl ColBatchMut<E>);
-    /// Solves the equation `conjugate(self) * X = rhs` when self is square, and stores the result in `rhs`.
+    /// Solves the equation `conjugate(self) * X = rhs` when self is square, and stores the result
+    /// in `rhs`.
     fn solve_conj_in_place(&self, rhs: impl ColBatchMut<E>);
-    /// Solves the equation `transpose(self) * X = rhs` when self is square, and stores the result in `rhs`.
+    /// Solves the equation `transpose(self) * X = rhs` when self is square, and stores the result
+    /// in `rhs`.
     fn solve_transpose_in_place(&self, rhs: impl ColBatchMut<E>);
-    /// Solves the equation `adjoint(self) * X = rhs` when self is square, and stores the result in `rhs`.
+    /// Solves the equation `adjoint(self) * X = rhs` when self is square, and stores the result in
+    /// `rhs`.
     fn solve_conj_transpose_in_place(&self, rhs: impl ColBatchMut<E>);
     /// Solves the equation `self * X = rhs` when self is square, and returns the result.
     fn solve<ViewE: Conjugate<Canonical = E>, B: ColBatch<ViewE>>(&self, rhs: B) -> B::Owned;


### PR DESCRIPTION
`visit_seq` is required if people want to use `serde` + `faer` with `bincode`.

See:
- https://github.com/bincode-org/bincode/issues/276

Basically, this PR only changed the position of `MatrixOrVecDeserializer` + `MatrixOrVec` and added the `visit_seq` method.

`cargo +nightly fmt` changed some code. Let me know if I need to revert these changes.